### PR TITLE
Feature/Add support for loading webarchive files from manifest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 billing_version = "6.1.0"
 browser_version = "1.5.0"
+webkit = "1.11.0"
 gradle_plugin_version = "7.4.2"
 mockk = "1.13.8"
 revenue_cat_version = "7.7.1"
@@ -33,6 +34,7 @@ revenue_cat = { module = "com.revenuecat.purchases:purchases", version.ref = "re
 
 # Browser
 browser = { module = "androidx.browser:browser", version.ref = "browser_version" }
+webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 
 # Compose
 compose_bom = { module = "androidx.compose:compose-bom", version.ref = "compose_version" }

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -185,7 +185,7 @@ dependencies {
 
     // Browser
     implementation(libs.browser)
-
+    implementation(libs.webkit)
 
     // Core
     implementation(libs.core)

--- a/superwall/src/main/java/com/superwall/sdk/logger/LogScope.kt
+++ b/superwall/src/main/java/com/superwall/sdk/logger/LogScope.kt
@@ -23,6 +23,7 @@ enum class LogScope {
     paywallViewController,
     nativePurchaseController,
     cache,
+    webarchive,
     all;
 
     override fun toString(): String {

--- a/superwall/src/main/java/com/superwall/sdk/models/config/WebArchiveManifest.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/WebArchiveManifest.kt
@@ -1,0 +1,46 @@
+package com.superwall.sdk.models.config
+
+import com.superwall.sdk.models.serialization.URLSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.net.URL
+
+@Serializable
+data class WebArchiveManifest(
+    @SerialName("use") val use: Usage,
+    @SerialName("document") val document: Document,
+    @SerialName("resources") val resources: List<Resource>
+) {
+    sealed interface ManifestPart {
+        val url: URL
+        val mimeType: String
+    }
+
+    @Serializable
+    enum class Usage {
+        @SerialName("IF_AVAILABLE_ON_PAYWALL_OPEN")
+        IF_AVAILABLE_ON_PAYWALL_OPEN,
+
+        @SerialName("NEVER")
+        NEVER,
+
+        @SerialName("ALWAYS")
+        ALWAYS
+    }
+
+    @Serializable
+    data class Document(
+        @SerialName("url")
+        override val url: @Serializable(with = URLSerializer::class) URL,
+        @SerialName("mime_type")
+        override val mimeType: String
+    ) : ManifestPart
+
+    @Serializable
+    data class Resource(
+        @SerialName("url")
+        override val url: @Serializable(with = URLSerializer::class) URL,
+        @SerialName("mime_type")
+        override val mimeType: String
+    ) : ManifestPart
+}

--- a/superwall/src/main/java/com/superwall/sdk/models/serialization/StringSerializableEntity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/serialization/StringSerializableEntity.kt
@@ -1,0 +1,30 @@
+package com.superwall.sdk.models.serialization
+
+import com.superwall.sdk.models.SerializableEntity
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/*
+ Complies pure Strings to SerializableEntity interface
+ for usage with current Endpoint abstraction.
+
+ TODO: Remove this class and use built-in String serializer
+ */
+@Serializable(with = StringSerializableEntity.StringSerializer::class)
+class StringSerializableEntity(
+    val value: String
+) : SerializableEntity {
+
+    @kotlinx.serialization.ExperimentalSerializationApi
+    @Serializer(forClass = StringSerializableEntity::class)
+    object StringSerializer : KSerializer<StringSerializableEntity> {
+        override fun serialize(encoder: Encoder, value: StringSerializableEntity) =
+            encoder.encodeString(value.value)
+
+        override fun deserialize(decoder: Decoder): StringSerializableEntity =
+            StringSerializableEntity(decoder.decodeString())
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
@@ -12,6 +12,7 @@ import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.paywall.Paywalls
 import com.superwall.sdk.models.postback.PostBackResponse
 import com.superwall.sdk.models.postback.Postback
+import com.superwall.sdk.models.serialization.StringSerializableEntity
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -283,6 +284,20 @@ data class Endpoint<Response : SerializableEntity>(
                 factory = factory
             )
         }
+
+        fun fetchRemoteFile(
+            url: URL,
+            factory: ApiFactory): Endpoint<StringSerializableEntity> {
+            return Endpoint(
+                components = Components(
+                    host = url.host, path = url.path
+                ),
+                method = HttpMethod.GET,
+                isForDebugging = true,
+                factory = factory
+            )
+        }
+
 //
 //        private fun paywallByIdentifier(
 //            identifier: String,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebViewClient.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebViewClient.kt
@@ -1,0 +1,26 @@
+package com.superwall.sdk.paywall.vc.web_view
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.webkit.WebResourceErrorCompat
+import androidx.webkit.WebViewClientCompat
+
+open class DefaultWebViewClient(
+    val onError: (
+        error: WebResourceErrorCompat
+    ) -> Unit
+) : WebViewClientCompat() {
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        return true
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest,
+        error: WebResourceErrorCompat
+    ) {
+        onError(error)
+    }
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
@@ -48,7 +48,6 @@ interface Storable<T> {
     val key: String
     val directory: SearchPathDirectory
     val serializer: KSerializer<T>
-
     fun path(context: Context): String {
         return directory.fileDirectory(context).absolutePath + File.separator + key.toMD5()
     }
@@ -239,6 +238,13 @@ object DisableVerboseEvents : Storable<Boolean> {
         get() = Boolean.serializer()
 }
 
+data class StoredWebArchive(
+    val payWallId: String
+) : Storable<String> {
+    override val key: String = "store.webarchive.$payWallId"
+    override val directory: SearchPathDirectory = SearchPathDirectory.CACHE
+    override val serializer: KSerializer<String> = String.serializer()
+}
 //endregion
 
 // region Serializers

--- a/superwall/src/main/java/com/superwall/sdk/storage/ReadWriteStorage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/ReadWriteStorage.kt
@@ -1,0 +1,13 @@
+package com.superwall.sdk.storage
+
+interface ReadWriteStorage {
+
+    // Writes to storage without serializing
+    fun writeFile(storable: Storable<*>, data: String)
+    // Reads from storage without serializing
+    fun readFile(storable: Storable<*>): String?
+    // Reads from storage and serializes into JSON
+    fun <T> get(storable: Storable<T>): T?
+    // Serializes into JSON and stores
+    fun <T : Any> save(data: T, storable: Storable<T>)
+}

--- a/superwall/src/main/java/com/superwall/sdk/storage/Storage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/Storage.kt
@@ -23,7 +23,7 @@ open class Storage(
     private val cache: Cache = Cache(context = context),
     /// The interface that manages core data.
     val coreDataManager: CoreDataManager = CoreDataManager(context = context)
-) {
+) : ReadWriteStorage {
     interface Factory: DeviceHelperFactory, HasExternalPurchaseControllerFactory {}
 
     /// The API key, set on configure.
@@ -194,12 +194,20 @@ open class Storage(
 
     //region Cache Reading & Writing
 
-    fun <T> get(storable: Storable<T>): T? {
+    override fun <T> get(storable: Storable<T>): T? {
         return cache.read(storable)
     }
 
-    fun <T: Any> save(data: T, storable: Storable<T>) {
+    override fun <T: Any> save(data: T, storable: Storable<T>) {
         cache.write(storable, data = data)
+    }
+
+    override fun writeFile(storable: Storable<*>, data: String) {
+        cache.writeFile(storable, data)
+    }
+
+    override fun readFile(storable: Storable<*>): String? {
+        return cache.readFile(storable)
     }
 
     //endregion

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/ManifestDownloader.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/ManifestDownloader.kt
@@ -1,0 +1,113 @@
+package com.superwall.sdk.webarchive
+
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
+import com.superwall.sdk.models.config.WebArchiveManifest
+import com.superwall.sdk.network.Network
+import com.superwall.sdk.webarchive.archive.ArchivePart
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import java.net.URL
+
+/*
+    Downloads WebArchive parts from a WebArchiveManifest.
+    Careful, performs a lot of requests in parallel.
+*/
+class ManifestDownloader(
+    private val coroutineScope: CoroutineScope,
+    private val network: Network
+) {
+
+    /*
+       Downloads the archive parts for a given manifest,
+       starting with the main document, then it's relative dependencies
+       and all other resources in parallel.
+    */
+    suspend fun downloadArchiveForManifest(
+        manifest: WebArchiveManifest
+    ): List<ArchivePart> {
+
+        // Download the main document
+        val mainDocumentUrl = manifest.document.url
+        val mainDocument = network.fetchRemoteFile(mainDocumentUrl)
+            .fold(onSuccess = { it }, onFailure = {
+                Logger.debug(
+                    logLevel = LogLevel.debug,
+                    scope = LogScope.webarchive,
+                    "Failed to download main document: $mainDocumentUrl",
+                    error = it,
+                    info = mapOf("url" to mainDocumentUrl.toString())
+                )
+                throw it
+            })
+
+        // Discover relative resources in the document (those without a full path)
+        val relativeUrls = discoverRelativeResources(mainDocument)
+        val host = mainDocumentUrl.host
+        val relativeParts = relativeUrls.map {
+            WebArchiveManifest.Resource(
+                url = URL("https://$host${it.key}"),
+                mimeType = it.value
+            )
+        }
+        val documentPart = ArchivePart.Document(
+            url = mainDocumentUrl.toString(),
+            content = mainDocument,
+            mimeType = manifest.document.mimeType
+        )
+
+        //Combine all resources into a list of deferred jobs
+        val jobs = (manifest.resources + relativeParts).map { resource ->
+            //Creates download tasks
+            coroutineScope.async {
+                with(resource) {
+                    network.fetchRemoteFile(url)
+                        .fold(onSuccess = {
+                            ArchivePart.Resource(
+                                url = url.toString(),
+                                mimeType = mimeType,
+                                content = it
+                            )
+                        }, onFailure = {
+                            Logger.debug(
+                                logLevel = LogLevel.debug,
+                                scope = LogScope.webarchive,
+                                "Failed to download resource: $url",
+                                error = it,
+                                info = mapOf("url" to url.toString())
+                            )
+                            throw it
+                        })
+                }
+            }
+        }
+        val parts = jobs.awaitAll() //Awaits the tasks in parallel
+        return listOf(documentPart) + parts
+    }
+
+    /*
+    Uses regex to match any relative resources in the main document that need
+    to be downloaded for the core runtime. This matches all ="/runtime/" resources
+    and returns a map of the relative path to the mime type judging by the extension
+    (with a special case for javascript files).
+    */
+    private fun discoverRelativeResources(mainDocument: String): Map<String, String> {
+        return Regex("=\"/runtime/[^\"]+\"")
+            .findAll(mainDocument)
+            .map {
+                //Drop =" and " from the match
+                it.value.drop(2).dropLast(1)
+            }
+            .map {
+                val type = when (val extension = it.takeLastWhile { it != '.' }) {
+                    "js" -> "javascript"
+                    else -> extension
+                }
+                val mimeType = "text/$type"
+                it to mimeType
+            }
+            .toMap()
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchiveCompressor.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchiveCompressor.kt
@@ -1,0 +1,150 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.storage.toMD5
+import com.superwall.sdk.webarchive.models.ArchiveKeys.CONTENT_ID
+import com.superwall.sdk.webarchive.models.ArchiveKeys.CONTENT_LOCATION
+import com.superwall.sdk.webarchive.models.ArchiveKeys.CONTENT_TRANSFER_ENCODING
+import com.superwall.sdk.webarchive.models.ArchiveKeys.CONTENT_TYPE
+import com.superwall.sdk.webarchive.models.ArchiveKeys.ContentId
+import com.superwall.sdk.webarchive.models.ArchiveKeys.TransferEncoding
+import com.superwall.sdk.webarchive.models.DecompressedWebArchive
+
+typealias CompressedWebArchive = String
+
+/*
+ Creates a multipart HTML file from a list of ArchiveParts and vice-versa
+*/
+class ArchiveCompressor(val encoder: ArchiveEncoder) {
+
+    fun compressToArchive(url: String, parts: List<ArchivePart>): CompressedWebArchive {
+        return parts.createMultipartHTML(url, encoder)
+    }
+
+    fun decompressArchive(archive: CompressedWebArchive): DecompressedWebArchive {
+
+        // Extract the header and the remaining content
+        val (headerParts, remaining) = archive.extractHeader()
+
+        // Find the boundary delimiter
+        val boundary = headerParts["boundary"]?.drop(1)?.dropLast(1)
+
+        // Split using the delimiter to get embedded documents
+        // Note: the first two dashes are used to indicate the start of the boundary
+        val parts = remaining.split("--$boundary")
+
+        val archiveParts = parts
+            // Filter out empty parts
+            .filter { !it.isBlank() }
+            .map {
+                // Extract map of content headers
+                val (headerParts, remaining) = it.extractHeader()
+                // Since some content can be text that is b64 encoded but not declared such
+                // we check if the content is base64 encoded by trying to decode it
+                val content = try {
+                    encoder.decodeDefault(remaining)
+                        .toString(Charsets.UTF_8)
+                } catch (e: Throwable) {
+                    remaining.trimEmptyLines()
+                }
+                headerParts to content
+            }.map {
+                val headers = it.first
+                val url = headers[CONTENT_LOCATION.key]?.trim() ?: ""
+                val mimeType = headers[CONTENT_TYPE.key]?.trim() ?: ""
+                val contentId = headers[CONTENT_ID.key]?.trim() ?: ""
+                if (contentId.contains(ContentId.MAIN_DOCUMENT.key)) {
+                    ArchivePart.Document(
+                        url = url,
+                        mimeType = mimeType,
+                        content = it.second
+                    )
+                } else ArchivePart.Resource(
+                    url = url,
+                    mimeType = mimeType,
+                    content = it.second
+                )
+            }
+        return DecompressedWebArchive(headerParts, archiveParts)
+    }
+
+    private fun String.trimEmptyLines() = lines()
+        .dropWhile { it.isEmpty() }
+        .joinToString("\n")
+        .trim()
+
+
+    // Creates multipart from a list of ArchiveParts and a base URL
+    fun List<ArchivePart>.createMultipartHTML(url: String, encoder: ArchiveEncoder): String {
+        val archiveHash = map { it.content }.joinToString(separator = "").toMD5()
+
+        //Generated boundary - a separator for different parts in a MHTML file
+        val boundary = "----MultipartBoundary--$archiveHash----"
+
+        // Header for the MHTML file, mostly unimportant except
+        // for the boundary and the content location
+        val header = listOf(
+            "From" to "<Saved by Superwall>",
+            "MIME-Version" to "1.0",
+            "Subject" to "Superwall Web Archive",
+            "Snapshot-Content-Location" to url,
+            "Content-Type" to "multipart/related;type=\"text/html\";boundary=\"$boundary\"",
+        ).joinToString("\n") { "${it.first}: ${it.second}" }
+
+        //Ensure document is first in the list
+        val document = find { it is ArchivePart.Document }
+        val resources = filter { it !is ArchivePart.Document }
+        //Join document and resources as parts separated by boundary
+        val combinedParts = (listOf(document) + resources)
+            .map {
+                it?.toMimePart(encoder)
+            }
+        //Return file as a combination of header and parts separated by boundary
+        return (listOf(header).plus(combinedParts)).joinToString(
+            "\n\n--$boundary\n",
+            postfix = "\n--$boundary"
+        )
+    }
+
+    // Extracts header parts of a mhtml and parses it into a map
+    private fun String.extractHeader(): Pair<Map<String, String>, String> {
+        val trimmed = lines().drop(lines().takeWhile { it.isBlank() }.size)
+        val header = trimmed
+            .takeWhile { it.isNotEmpty() }
+
+        val headerParts = header.flatMap {
+            it.split(": ", ";", "=")
+                .chunked(2).map { it.first().trim() to it.last() }
+        }.toMap()
+
+        val remaining = trimmed.drop(header.size).joinToString("\n")
+        return headerParts to remaining
+    }
+
+}
+
+fun ArchivePart.toMimePart(encoder: ArchiveEncoder): String {
+
+    val content = when (this) {
+        is ArchivePart.Document ->
+            content
+
+        is ArchivePart.Resource -> {
+            if (mimeType.contains("text"))
+                content
+            else {
+                val defaultEncoded = encoder.decodeDefault(content)
+                encoder.encode(defaultEncoded)
+            }
+        }
+    }
+
+    val header = listOf(
+        CONTENT_TYPE to mimeType,
+        CONTENT_TRANSFER_ENCODING to if (mimeType.contains("text"))
+            TransferEncoding.QUOTED_PRINTABLE.key else TransferEncoding.BASE64.key,
+        CONTENT_LOCATION to url,
+        CONTENT_ID to contentId,
+    ).joinToString("") { "${it.first.key}: ${it.second}\n" }
+
+    return "$header\n\n$content"
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchiveEncoder.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchiveEncoder.kt
@@ -1,0 +1,10 @@
+package com.superwall.sdk.webarchive.archive
+
+interface ArchiveEncoder {
+
+    fun encode(content: ByteArray): String
+
+    fun decode(content: ByteArray): ByteArray
+
+    fun decodeDefault(string: String): ByteArray
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchivePart.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/ArchivePart.kt
@@ -1,0 +1,27 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.webarchive.models.ArchiveKeys
+
+sealed interface ArchivePart {
+    val url: String
+    val mimeType: String
+    val content: String
+    val contentId: String
+
+    data class Resource(
+        override val url: String,
+        override val mimeType: String,
+        override val content: String,
+    ): ArchivePart {
+        override val contentId: String = ""
+    }
+
+    data class Document(
+        override val url: String,
+        override val mimeType: String,
+        override val content: String
+    ): ArchivePart {
+        override val contentId: String = ArchiveKeys.ContentId.MAIN_DOCUMENT.key
+    }
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/Base64ArchiveEncoder.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/Base64ArchiveEncoder.kt
@@ -1,0 +1,28 @@
+package com.superwall.sdk.webarchive.archive
+
+import android.util.Base64
+
+/**
+ * Base64 implementation of archive encoder
+ * with specific encoding width for compatibility with
+ * chrome's export format and email clients
+ */
+class Base64ArchiveEncoder : ArchiveEncoder {
+    override fun encode(content: ByteArray): String {
+        return Base64.encodeToString(content, Base64.NO_WRAP, 76, Base64.DEFAULT)
+    }
+
+    /*Decodes default B64*/
+    override fun decodeDefault(string: String): ByteArray {
+        return Base64.decode(string, Base64.DEFAULT)
+    }
+
+    override fun decode(content: ByteArray): ByteArray {
+        return Base64.decode(
+            content, Base64.NO_WRAP,
+            76,
+            Base64.DEFAULT
+        )
+    }
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/CachedArchiveLibrary.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/CachedArchiveLibrary.kt
@@ -1,0 +1,74 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.models.config.WebArchiveManifest
+import com.superwall.sdk.storage.ReadWriteStorage
+import com.superwall.sdk.storage.StoredWebArchive
+import com.superwall.sdk.webarchive.ManifestDownloader
+import com.superwall.sdk.webarchive.models.DecompressedWebArchive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+
+/**
+ * Manages WebArchives, downloading and saving them to file cache.
+ */
+class CachedArchiveLibrary(
+    private val storage: ReadWriteStorage,
+    private val manifestDownloader: ManifestDownloader,
+    private val archiveCompressor: ArchiveCompressor,
+) : WebArchiveLibrary {
+
+    // Queue of paywallIds that are currently being downloaded
+    private val archiveQueue = MutableStateFlow(listOf<String>())
+    override suspend fun downloadManifest(
+        paywallId: String,
+        paywallUrl: String,
+        archiveFile: WebArchiveManifest
+    ) {
+
+        // Return if the paywall is already archived or waiting to be archived
+        if (checkIfArchived(paywallId) || archiveQueue.value.contains(paywallId))
+            return
+
+        archiveQueue.update {
+            it + paywallId
+        }
+
+        val archive = manifestDownloader.downloadArchiveForManifest(archiveFile)
+        val mhtmlContent = archiveCompressor.compressToArchive(paywallUrl, archive)
+        val storable = StoredWebArchive(paywallId)
+        storage.writeFile(
+            storable = storable,
+            data = mhtmlContent,
+        )
+        archiveQueue.update {
+            it.minus(paywallId)
+        }
+    }
+
+    // Check if the paywall is archived already
+    override fun checkIfArchived(paywallId: String): Boolean {
+        val archive = StoredWebArchive(paywallId)
+        return storage.readFile(archive) != null
+    }
+
+    // Load the archive from cache, if it does not exist, throw an exception
+    override suspend fun loadArchive(paywallId: String): Result<DecompressedWebArchive> {
+        //If doesn't exist, await until it's downloaded
+        if (!checkIfArchived(paywallId))
+            awaitUntilQueueResolved(paywallId)
+        val storeable = StoredWebArchive(paywallId)
+        val fromCache = storage.readFile(storeable)
+        return if (fromCache != null) {
+            val decompressed = archiveCompressor.decompressArchive(fromCache)
+            Result.success(decompressed)
+        } else {
+            Result.failure(NoSuchElementException("Paywall $paywallId does not exist in cache"))
+        }
+    }
+
+    // Checks and awaits if the paywall is in queue, otherwise returns immediately
+    private suspend fun awaitUntilQueueResolved(paywallId: String) = archiveQueue.first {
+        !it.contains(paywallId)
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/archive/WebArchiveLibrary.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/archive/WebArchiveLibrary.kt
@@ -1,0 +1,15 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.models.config.WebArchiveManifest
+import com.superwall.sdk.webarchive.models.DecompressedWebArchive
+
+interface WebArchiveLibrary {
+
+    suspend fun downloadManifest(paywallId: String,
+                                 paywallUrl: String,
+                                 archiveFile: WebArchiveManifest)
+    fun checkIfArchived(paywallId: String) : Boolean
+
+    suspend fun loadArchive(paywallId: String) : Result<DecompressedWebArchive>
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/client/ArchiveWebClient.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/client/ArchiveWebClient.kt
@@ -1,0 +1,105 @@
+package com.superwall.sdk.webarchive.client
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.webkit.WebResourceErrorCompat
+import androidx.webkit.WebViewAssetLoader
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
+import com.superwall.sdk.paywall.vc.web_view.DefaultWebViewClient
+import com.superwall.sdk.webarchive.archive.ArchiveEncoder
+import com.superwall.sdk.webarchive.archive.ArchivePart
+import com.superwall.sdk.webarchive.archive.Base64ArchiveEncoder
+import com.superwall.sdk.webarchive.models.DecompressedWebArchive
+import com.superwall.sdk.webarchive.models.MimeType
+
+/*
+* Routes requests coming to specific URLs to WebArchive files.
+* */
+open class ArchiveWebClient(
+    private val archive: DecompressedWebArchive,
+    private val encoder : ArchiveEncoder = Base64ArchiveEncoder(),
+    onError: (WebResourceErrorCompat) -> Unit
+) : DefaultWebViewClient(onError) {
+
+    companion object {
+        const val OVERRIDE_PATH = "https://appassets.androidplatform.net/assets/index.html"
+    }
+
+    val assetLoader = WebViewAssetLoader.Builder()
+        // Requests coming towards these paths will be intercepted
+        .addPathHandler("/assets/") { uri ->
+            resolveUrlFromArchive(archive, uri)
+        }
+        .addPathHandler("/runtime/") { uri ->
+            resolveUrlFromArchive(archive, uri)
+        }
+        .build()
+
+    override fun shouldInterceptRequest(
+        view: WebView,
+        request: WebResourceRequest
+    ): WebResourceResponse? {
+        return assetLoader.shouldInterceptRequest(Uri.parse(request.url.toString()))
+    }
+
+
+    override fun shouldInterceptRequest(
+        view: WebView?,
+        url: String
+    ): WebResourceResponse? {
+        return assetLoader.shouldInterceptRequest(Uri.parse(url))
+    }
+
+    /*
+    Given an URL and an archive, resolves the URL by looking it up in the archive.
+    A special case is when the URL is the index.html, in which case we look for the
+    content type text/html and contentId=index.
+    * */
+    private fun resolveUrlFromArchive(
+        archiveFile: DecompressedWebArchive,
+        url: String
+    ): WebResourceResponse {
+        // Find the part that matches the requested url or the main document
+        // Since they can be relative paths, it checks via .contains
+        val part = archiveFile.content.find { part ->
+            if (url.contains("index.html")) {
+                part is ArchivePart.Document
+            } else {
+                part.url.contains(url)
+            }
+        }
+        if(part == null) {
+            Logger.debug(
+                logLevel = LogLevel.debug,
+                scope = LogScope.webarchive,
+                message = "No part found for $url",
+            )
+            return WebResourceResponse(MimeType.HTML.toString(), "UTF-8", null)
+        }
+        val mimeType = part.mimeType
+        return when (MimeType.fromString(mimeType).type) {
+            "text" -> {
+                // Respond with the content as text
+                val response =
+                    WebResourceResponse(
+                        mimeType,
+                        "UTF-8",
+                        part.content.byteInputStream()
+                    )
+                response
+            }
+
+            else -> {
+                // Decode content as base64
+                val unbased = encoder.decode(part.content.encodeToByteArray())
+                val response = WebResourceResponse(mimeType.toString(), "UTF-8", unbased.inputStream())
+                response
+            }
+        }
+    }
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/models/ArchiveKeys.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/models/ArchiveKeys.kt
@@ -1,0 +1,23 @@
+package com.superwall.sdk.webarchive.models
+
+enum class ArchiveKeys(val key: String) {
+    CONTENT_TYPE("Content-Type"),
+    CONTENT_ID("Content-Id"),
+    CONTENT_LOCATION("Content-Location"),
+    CONTENT_TRANSFER_ENCODING("Content-Transfer-Encoding");
+
+    override fun toString() = key
+
+    enum class TransferEncoding(val key: String) {
+        QUOTED_PRINTABLE("quoted-printable"),
+        BASE64("base64");
+
+        override fun toString() = key
+    }
+
+    enum class ContentId(val key: String) {
+        MAIN_DOCUMENT("<mainDocument>");
+        override fun toString() = key
+    }
+
+}

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/models/DecompressedWebArchive.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/models/DecompressedWebArchive.kt
@@ -1,0 +1,8 @@
+package com.superwall.sdk.webarchive.models
+
+import com.superwall.sdk.webarchive.archive.ArchivePart
+
+data class DecompressedWebArchive(
+    val header: Map<String, String>,
+    val content: List<ArchivePart>
+)

--- a/superwall/src/main/java/com/superwall/sdk/webarchive/models/MimeType.kt
+++ b/superwall/src/main/java/com/superwall/sdk/webarchive/models/MimeType.kt
@@ -1,0 +1,28 @@
+package com.superwall.sdk.webarchive.models
+
+data class MimeType(
+    val type: String,
+    val subtype: String
+) {
+    companion object {
+        fun fromString(mimeType: String): MimeType {
+            val parts = mimeType.split("/")
+            return MimeType(parts[0], parts[1])
+        }
+
+        val HTML = MimeType("text", "html")
+
+    }
+
+    override fun toString(): String {
+        return "$type/$subtype"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        when (other) {
+            is MimeType -> return type == other.type && subtype == other.subtype
+            is String -> return toString() == other
+            else -> return super.equals(other)
+        }
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/utils.kt
+++ b/superwall/src/test/java/com/superwall/sdk/utils.kt
@@ -11,3 +11,41 @@ fun assertFalse(value: Boolean) {
         throw AssertionError("Expected false, got true")
     }
 }
+
+@DslMarker annotation class TestingDSL
+
+class GivenWhenThenScope(val text: MutableList<String>)
+
+@TestingDSL
+inline fun Given(what: String, block: GivenWhenThenScope.() -> Unit) {
+    val scope = GivenWhenThenScope(mutableListOf("Given $what"))
+    try {
+        block(scope)
+    }catch (e: Throwable){
+        e.printStackTrace()
+        println(scope.text.joinToString("\n"))
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun <T> GivenWhenThenScope.When(what: String, block: GivenWhenThenScope.() -> T): T {
+    text.add("\tWhen $what")
+    try {
+        return block(this)
+    }catch (e: Throwable){
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.Then(what: String, block: GivenWhenThenScope.() -> Unit) {
+    text.add("\t\tThen $what")
+    block()
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.And(what: String, block: GivenWhenThenScope.() -> Unit) {
+    text.add("\t\t\tAnd $what")
+    block()
+}

--- a/superwall/src/test/java/com/superwall/sdk/webarchive/ManifestDownloaderTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/webarchive/ManifestDownloaderTest.kt
@@ -1,0 +1,86 @@
+package com.superwall.sdk.webarchive
+
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import com.superwall.sdk.models.config.WebArchiveManifest
+import com.superwall.sdk.network.Network
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.net.URL
+
+class ManifestDownloaderTest {
+
+    private val docUrl = "https://example.com"
+    private val resUrl = "https://example.com/image.jpg"
+    private val relativeLink = "https://example.com/runtime/test.js"
+    private val docContent = "document content"
+    private val resContent = "resource content"
+    private val relativeContent = "<script src='relative.js'></script>"
+    private val network = mockk<Network> {
+        coEvery { fetchRemoteFile(URL(docUrl)) } coAnswers { Result.success(docContent) }
+        coEvery { fetchRemoteFile(URL(resUrl)) } coAnswers { Result.success(resContent) }
+        coEvery { fetchRemoteFile(URL(relativeLink)) } coAnswers { Result.success(relativeContent) }
+    }
+
+    @Test
+    fun `should download document and resources from manifest`() = runTest {
+        Given("a manifest document and resources") {
+            val manifest = WebArchiveManifest(
+                WebArchiveManifest.Usage.ALWAYS,
+                WebArchiveManifest.Document(
+                    url = URL(docUrl),
+                    mimeType = "text/html"
+                ),
+                listOf(
+                    WebArchiveManifest.Resource(
+                        url = URL(resUrl),
+                        mimeType = "image/jpeg"
+                    )
+                )
+            )
+            When("the manifest is downloaded") {
+                val downloader = ManifestDownloader(this@runTest, network)
+                val res = downloader.downloadArchiveForManifest(manifest)
+                Then("the document and resources should be downloaded") {
+                    assert(res.size == 2)
+                    assert(res[0].content == docContent)
+                    assert(res[1].content == resContent)
+                }
+            }
+        }
+    }
+
+
+    @Test
+    fun `should download relative links when document contains them`() = runTest {
+        Given("a manifest document and resources") {
+            coEvery { network.fetchRemoteFile(URL(docUrl)) } coAnswers { Result.success("<a href=\"/runtime/test.js\"") }
+            val manifest = WebArchiveManifest(
+                WebArchiveManifest.Usage.ALWAYS,
+                WebArchiveManifest.Document(
+                    url = URL(docUrl),
+                    mimeType = "text/html"
+                ),
+                listOf(
+                    WebArchiveManifest.Resource(
+                        url = URL(resUrl),
+                        mimeType = "image/jpeg"
+                    )
+                )
+            )
+            When("the manifest is downloaded") {
+                val downloader = ManifestDownloader(this@runTest, network)
+                val res = downloader.downloadArchiveForManifest(manifest)
+                Then("the document and resources should be downloaded") {
+                    assert(res.size == 3)
+                    assert(res[2].content == relativeContent)
+                }
+            }
+        }
+    }
+
+
+}

--- a/superwall/src/test/java/com/superwall/sdk/webarchive/archive/ArchiveCompressorTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/webarchive/archive/ArchiveCompressorTest.kt
@@ -1,0 +1,159 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import com.superwall.sdk.storage.toMD5
+import com.superwall.sdk.webarchive.models.ArchiveKeys
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+
+class ArchiveCompressorTest {
+
+    private val encoder = mockk<ArchiveEncoder>()
+
+    @Test
+    fun `archive document part should map to mime part`() {
+        Given("A document part") {
+            val part = ArchivePart.Document("url", "text/html", "content")
+            When("toMimePart is called") {
+                val mimePart = part.toMimePart(encoder)
+                Then("it should return the proper mimepart") {
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TYPE}: text/html"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TRANSFER_ENCODING}: quoted-printable"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_LOCATION}: url"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_ID}: <mainDocument>"))
+                    assert(mimePart.contains("content"))
+                }
+            }
+        }
+    }
+
+
+    @Test
+    fun `archive resource part should map to mime part`() {
+        Given("A resource part") {
+            val part = ArchivePart.Resource("url", "text/css", "content")
+            When("toMimePart is called") {
+                val mimePart = part.toMimePart(encoder)
+                Then("it should return the proper mimepart") {
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TYPE}: text/css"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TRANSFER_ENCODING}: quoted-printable"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_LOCATION}: url"))
+                    assert(mimePart.contains("content"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `archive resource part should map to b64 encoded mime`() {
+
+        val content = "content"
+        val decoded = "decoded".toByteArray()
+        val result = "result"
+        every { encoder.decodeDefault(content) } returns decoded
+        every { encoder.encode(decoded) } returns result
+        Given("A resource part") {
+            val part = ArchivePart.Resource("url", "image/png", "content")
+            When("toMimePart is called") {
+                val mimePart = part.toMimePart(encoder)
+                Then("it should return the proper mimepart") {
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TYPE}: image/png"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_TRANSFER_ENCODING}: base64"))
+                    assert(mimePart.contains("${ArchiveKeys.CONTENT_LOCATION}: url"))
+                    assert(mimePart.contains(result))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `compressor should create a proper multipart file from parts`() {
+        val parts = listOf(
+            ArchivePart.Document("url", "text/html", "content"),
+            ArchivePart.Resource("url", "mimeType", "content")
+        )
+
+        val content = "content"
+        val decoded = "decoded".toByteArray()
+        val result = "result"
+        every { encoder.decodeDefault(content) } returns decoded
+        every { encoder.encode(decoded) } returns result
+
+        val archiveHash = parts.map { it.content }.joinToString(separator = "").toMD5()
+
+        val boundary = "----MultipartBoundary--$archiveHash----"
+
+        val header = listOf(
+            "From" to "<Saved by Superwall>",
+            "MIME-Version" to "1.0",
+            "Subject" to "Superwall Web Archive",
+            "Snapshot-${ArchiveKeys.CONTENT_LOCATION.key}" to "url",
+            "${ArchiveKeys.CONTENT_TYPE}" to "multipart/related;type=\"text/html\";boundary=\"$boundary\"",
+        ).joinToString("\n") { "${it.first}: ${it.second}" }
+
+
+        Given("A list of archive parts") {
+            When("createMultipartHTML is called") {
+                val compressor = ArchiveCompressor(encoder)
+                val multipart = compressor.compressToArchive("url", parts)
+                Then("it should return the proper multipart file") {
+                    assert(multipart.contains(header))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_TYPE}: text/html"))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_TRANSFER_ENCODING}: quoted-printable"))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_LOCATION}: url"))
+                    assert(multipart.contains("content"))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_TYPE}: mimeType"))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_TRANSFER_ENCODING}: quoted-printable"))
+                    assert(multipart.contains("${ArchiveKeys.CONTENT_LOCATION}: url"))
+                    assert(multipart.contains("content"))
+                    assert(multipart.split(boundary).size == 5)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `compressor should be able to decompress its files back`(){
+        val parts = listOf(
+            ArchivePart.Document("url", "text/html", "content"),
+            ArchivePart.Resource("url", "mimeType", "resource content"),
+            ArchivePart.Resource("url", "text/javascript", "javascripthere")
+        )
+
+
+        val encoder = object : ArchiveEncoder {
+            override fun encode(content: ByteArray) = content.toString(Charsets.UTF_8)
+            override fun decode(string: ByteArray) = string
+
+            override fun decodeDefault(string: String) = string.toByteArray()
+
+        }
+        val compressor = ArchiveCompressor(encoder)
+        Given("A compressed archive file") {
+        val archiveFile = compressor.compressToArchive("url", parts)
+            When("decompressArchive is called") {
+                val decompressed = compressor.decompressArchive(archiveFile)
+                Then("it should return the proper decompressed archive") {
+                    assert(decompressed.content.size == 3)
+                    val doc = decompressed.content[0]
+                    assert(doc.mimeType == "text/html")
+                    assert(doc.url == "url")
+                    assert(doc.content.trim() == "content")
+                    val res = decompressed.content[1]
+                    assert(res.mimeType == "mimeType")
+                    assert(res.url == "url")
+                    assert(res.content.trim() == "resource content")
+
+                    val js = decompressed.content[2]
+                    assert(js.mimeType == "text/javascript")
+                    assert(js.url == "url")
+                    assert(js.content.trim() == "javascripthere")
+
+                }
+            }
+        }
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/webarchive/archive/CachedArchiveLibraryTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/webarchive/archive/CachedArchiveLibraryTest.kt
@@ -1,0 +1,145 @@
+package com.superwall.sdk.webarchive.archive
+
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import com.superwall.sdk.models.config.WebArchiveManifest
+import com.superwall.sdk.network.Network
+import com.superwall.sdk.storage.ReadWriteStorage
+import com.superwall.sdk.storage.StoredWebArchive
+import com.superwall.sdk.webarchive.ManifestDownloader
+import com.superwall.sdk.webarchive.models.DecompressedWebArchive
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class CachedArchiveLibraryTest {
+
+    val paywallUrl = "paywallUrl"
+    val paywallId = "paywallId"
+    val storable = StoredWebArchive(paywallId)
+
+    val storage = mockk<ReadWriteStorage>()
+    val network = mockk<Network>()
+    val manifestDownloader = mockk<ManifestDownloader>()
+    val encoder = mockk<ArchiveEncoder>() {
+        every { encode(any()) } returns "encoded"
+        every { decodeDefault(any()) } returns "decoded".toByteArray()
+        every { decode(any() as ByteArray) } returns "decoded".toByteArray()
+
+    }
+
+    val mockParts = listOf(
+        ArchivePart.Document("url", "text/html", "content"),
+        ArchivePart.Resource("url", "mimeType", "content")
+    )
+
+    @Test
+    fun `downloadManifest should save archive to storage`() = runTest {
+        val manifest = mockk<WebArchiveManifest>()
+        val downloader = manifestDownloader
+        val paywallUrl = "paywallUrl"
+        every { storage.readFile(storable) } returns null
+        every { storage.writeFile(storable, any()) } just Runs
+
+        Given("A valid manifest that has not been saved before") {
+            val archiveLibrary =
+                CachedArchiveLibrary(storage, downloader, ArchiveCompressor(encoder))
+            coEvery { downloader.downloadArchiveForManifest(manifest) } returns mockParts
+            When("downloadManifest is called") {
+                archiveLibrary.downloadManifest(paywallId, paywallUrl, manifest)
+                Then("the archive should be saved to storage") {
+                    verify { storage.writeFile(storable,any()) }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `downloadManifest should not save archive to storage if it already exists`() = runTest {
+        val manifest = mockk<WebArchiveManifest>()
+        val downloader = manifestDownloader
+        every { storage.readFile(storable) } returns "file content"
+
+        Given("A valid manifest that has been saved before") {
+            val archiveLibrary =
+                CachedArchiveLibrary(storage, downloader, ArchiveCompressor(encoder))
+            When("downloadManifest is called") {
+                archiveLibrary.downloadManifest(paywallId, paywallUrl, manifest)
+                Then("the archive should not be downloaded or saved to storage") {
+                    coVerify(exactly = 0) {
+                        downloader.downloadArchiveForManifest(manifest)
+                    }
+                    coVerify(exactly = 0) {
+                        storage.writeFile(storable,any())
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `loadArchive should return the archive from storage if it exists`() = runTest {
+        val archiveFile = "archive"
+        val arch = DecompressedWebArchive(emptyMap(), emptyList())
+        val compressor = mockk<ArchiveCompressor>() {
+            coEvery { compressToArchive(paywallUrl, mockParts) } returns archiveFile
+            coEvery { decompressArchive(archiveFile) } returns arch
+        }
+        every { storage.readFile(storable) } returns archiveFile
+
+        Given("A paywall ID that exists in storage") {
+            val archiveLibrary =
+                CachedArchiveLibrary(storage, manifestDownloader,compressor )
+            When("loadArchive is called") {
+                val result = archiveLibrary.loadArchive(paywallId)
+                Then("the archive should be returned from storage") {
+                    assert(result.isSuccess)
+                    assert(result.getOrNull() == arch)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `loadArchive should wait for the archive to be downloaded if it does not exist in storage`() =
+        runTest {
+            val archiveFile = "archive"
+            val arch = DecompressedWebArchive(emptyMap(), emptyList())
+            val manifest = mockk<WebArchiveManifest>()
+            val compressor = mockk<ArchiveCompressor>() {
+                coEvery { compressToArchive(paywallUrl, mockParts) } returns archiveFile
+                coEvery { decompressArchive(archiveFile) } returns arch
+            }
+            every { storage.readFile(storable) } returns null
+
+            coEvery { manifestDownloader.downloadArchiveForManifest(manifest) }.coAnswers {
+                delay(100)
+                mockParts
+            }
+            every { storage.readFile(storable) } returns archiveFile
+
+            Given("A paywall ID that does not exist in storage") {
+                val archiveLibrary =
+                    CachedArchiveLibrary(storage, manifestDownloader, compressor)
+                When("loadArchive is called before it is downloaded") {
+                    launch { archiveLibrary.downloadManifest(paywallId, paywallUrl, manifest) }
+                    val result = archiveLibrary.loadArchive(paywallId)
+
+                    Then("the archive should be returned from storage") {
+                        assert(result.isSuccess)
+                        assert(result.getOrNull() == arch)
+                    }
+                }
+            }
+        }
+}
+


### PR DESCRIPTION
### What

* Adds `manifest : WebArchiveManifest` field to `Paywall` to enable saving paywall as archive
* Adds `WebArchiveLibrary` and `ArchiveCompressor` to manage and de/compress MHTML files given a manifest.
* Adds `ManifestDownloader` to download manifest as File's
* Adds support for non-serializable fetching via current Network layer
* Adds support for non-serializable writing to current Storage layer
* Adds a small DSL for prettier tests with nice crash output
* Refactors WebViewClient into a `DefaultWebViewClient` and an `ArchiveWebClient` relying on `androix.webkit.WebViewAssetLoader` to load local files 

### How


#### Downloading
- When a configuration is fetched, it checks for paywalls with manifests and queues them up for a download via `WebArchiveLibrary`. The library checks if a `Manifest` is downloaded already or is in Queue, then either skips it or downloads it if necessary. 
- The declared files and their necessary reference are downloaded in parallel and compressed into the archive itself. 
- Once a paywall and all it's related files (be it from manifest or referenced from the body itself) are downloaded, 
- `ArchiveCompressor` compresses them into an MHTML file and stores them to disk

#### Viewing
- When a paywall is loaded, depending on the Manifest usage flag it either checks if manifest exists and loads URL if not, or awaits for the manifest to download before loading
- The manifest is decompressed into a set of files and all webview requests are routed to those files through a mock host URL, done by `WebArchiveClient` overriding the URL requests

#### Extra

Adds a small Given/When/Then testing DSL to make reading/understanding tests easier
