### PR TITLE
Fix leaking activity context

### DIFF
--- a/example/app/src/main/java/com/superwall/exampleapp/MainActivity.kt
+++ b/example/app/src/main/java/com/superwall/exampleapp/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.superwall.exampleapp
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -45,7 +44,6 @@ import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import com.superwall.exampleapp.ui.theme.SuperwallExampleAppTheme
 import com.superwall.sdk.Superwall
-import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.identity.identify
 import com.superwall.sdk.identity.setUserAttributes
 
@@ -55,8 +53,7 @@ class MainActivity : ComponentActivity() {
 
         Superwall.configure(
             applicationContext = this,
-            apiKey = "pk_3b18882b1683318b710c741f371f40f54e357c6f0baff1f4",
-            options = SuperwallOptions().apply { paywalls.shouldPreload = false }
+            apiKey = "pk_3b18882b1683318b710c741f371f40f54e357c6f0baff1f4"
         )
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -137,10 +134,7 @@ fun WelcomeScreen() {
                 Spacer(modifier = Modifier.weight(1f))
 
                 Button(
-                    onClick = {
-                        startHomeActivity(context, name)
-                        (context as Activity).finish()
-                    },
+                    onClick = { startHomeActivity(context, name) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 50.dp)

--- a/example/app/src/main/java/com/superwall/exampleapp/MainActivity.kt
+++ b/example/app/src/main/java/com/superwall/exampleapp/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.superwall.exampleapp
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -44,6 +45,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import com.superwall.exampleapp.ui.theme.SuperwallExampleAppTheme
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.identity.identify
 import com.superwall.sdk.identity.setUserAttributes
 
@@ -53,7 +55,8 @@ class MainActivity : ComponentActivity() {
 
         Superwall.configure(
             applicationContext = this,
-            apiKey = "pk_3b18882b1683318b710c741f371f40f54e357c6f0baff1f4"
+            apiKey = "pk_3b18882b1683318b710c741f371f40f54e357c6f0baff1f4",
+            options = SuperwallOptions().apply { paywalls.shouldPreload = false }
         )
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -134,7 +137,10 @@ fun WelcomeScreen() {
                 Spacer(modifier = Modifier.weight(1f))
 
                 Button(
-                    onClick = { startHomeActivity(context, name) },
+                    onClick = {
+                        startHomeActivity(context, name)
+                        (context as Activity).finish()
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 50.dp)

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -232,10 +232,11 @@ class Superwall(
                 completion?.invoke()
                 return
             }
+            val forcedApplicationContext = applicationContext.applicationContext
             val purchaseController =
-                purchaseController ?: ExternalNativePurchaseController(context = applicationContext)
+                purchaseController ?: ExternalNativePurchaseController(context = forcedApplicationContext)
             instance = Superwall(
-                context = applicationContext,
+                context = forcedApplicationContext,
                 apiKey = apiKey,
                 purchaseController = purchaseController,
                 options = options,


### PR DESCRIPTION
Despite clear instructions in Superwall SDK's docs to pass the application context to the `Superwall.configure()` method, given no type safe distinction between activity context and application context, it's possible to mistakenly pass an activity context, like in the [example app](https://github.com/superwall/Superwall-Android/blob/1.1.5/example/app/src/main/java/com/superwall/exampleapp/MainActivity.kt#L55). That can lead to memory leaks, as the SDK holds a reference to the context for its whole lifecycle that is longer than lifecycle of an Activity.
It can also cause app crashes, for example when initialising `JavaScriptSandbox` after the activity is finished.
Steps to reproduce the crash in Example application:
* Disable Paywalls preloading, e.g. in [Superwall options](https://github.com/superwall/Superwall-Android/commit/cf6a701ac1d6f4ed9cadf9f7303d060f7fbd0050#diff-d4ac9c78e0c9fb9d45208b1d09295a85de7c007ef249c1406e7c9252818482a0R59) 
* [Finish](https://github.com/superwall/Superwall-Android/commit/cf6a701ac1d6f4ed9cadf9f7303d060f7fbd0050#diff-d4ac9c78e0c9fb9d45208b1d09295a85de7c007ef249c1406e7c9252818482a0R142) `MainActivity` when navigating to `HomeActivity`
* Run Example app
* Click "Log in" and "Launch Feature" to initialise `JavaScriptSandbox` after `MainActivity` is finished.

Logs:
```
FATAL EXCEPTION: ExpressionEvaluator
Process: com.superwall.superapp, PID: 21254
java.lang.RuntimeException: bindService() returned false Intent { cmp=com.google.android.webview/org.chromium.android_webview.js_sandbox.service.JsSandboxService0 }
	at androidx.javascriptengine.JavaScriptSandbox.lambda$bindToServiceWithCallback$1(JavaScriptSandbox.java:423)
	at androidx.javascriptengine.JavaScriptSandbox$$ExternalSyntheticLambda0.attachCompleter(Unknown Source:6)
	at androidx.concurrent.futures.CallbackToFutureAdapter.getFuture(CallbackToFutureAdapter.java:102)
	at androidx.javascriptengine.JavaScriptSandbox.bindToServiceWithCallback(JavaScriptSandbox.java:410)
	at androidx.javascriptengine.JavaScriptSandbox.createConnectedInstanceAsync(JavaScriptSandbox.java:358)
	at com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator.ExpressionEvaluator$1.invokeSuspend(ExpressionEvaluator.kt:54)
```

To avoid errors, the SDK can precautionary get application context from the context passed into `Superwall.configure()` method.
Given that, the SDK requirements could get relaxed to allow initialisation with activity context.