### PR TITLE
Fix PaywallComposable size

### DIFF
--- a/app/src/main/java/com/superwall/superapp/MainApplication.kt
+++ b/app/src/main/java/com/superwall/superapp/MainApplication.kt
@@ -2,7 +2,6 @@ package com.superwall.superapp
 
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
-import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.paywall.presentation.register
 
@@ -36,8 +35,7 @@ class MainApplication : android.app.Application(), SuperwallDelegate {
     fun configureWithAutomaticInitialization() {
         Superwall.configure(
             this,
-            CONSTANT_API_KEY,
-            options = SuperwallOptions().apply { paywalls.shouldPreload = false }
+            CONSTANT_API_KEY
         )
         Superwall.instance.delegate = this
 

--- a/app/src/main/java/com/superwall/superapp/MainApplication.kt
+++ b/app/src/main/java/com/superwall/superapp/MainApplication.kt
@@ -2,6 +2,7 @@ package com.superwall.superapp
 
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
+import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.paywall.presentation.register
 
@@ -35,7 +36,8 @@ class MainApplication : android.app.Application(), SuperwallDelegate {
     fun configureWithAutomaticInitialization() {
         Superwall.configure(
             this,
-            CONSTANT_API_KEY
+            CONSTANT_API_KEY,
+            options = SuperwallOptions().apply { paywalls.shouldPreload = false }
         )
         Superwall.instance.delegate = this
 

--- a/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
@@ -79,6 +79,7 @@ fun PaywallComposable(
                     }
                 }
                 AndroidView(
+                    modifier = Modifier.fillMaxSize(),
                     factory = { context ->
                         viewToRender
                     }


### PR DESCRIPTION
If a Paywall's WebView is not loaded the `PaywallComposable` is added to the view hierarchy, the height of the `PaywallViewController` becomes 0 after the `ShimmerView` is hidden.
To reproduce this issue in the `app` included in this repository, follow these steps:
* Disable Paywalls preloading
* Run the `app` 
* Click the "JETPACK COMPOSE" button

Result: "Tab 0" content is empty after shimmer gets hidden
![superwall](https://github.com/superwall/Superwall-Android/assets/2682125/0164f36e-087a-4c78-a888-9f8f3e669208)
<img width="945" alt="Screenshot 2024-05-13 at 16 14 15" src="https://github.com/superwall/Superwall-Android/assets/2682125/7888947f-add1-4fff-a78b-efd50cabc513">

The solution is to specify the preferred size of the `AndroidView` that contains the `PaywallViewController`