### PR TITLE
1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.1.6
+
+### Enhancements
+
+- SW-2833: Adds support for dark mode paywall background color.
+-  Adds ability to target devices based on their IP address location. Use `device.ipRegion`, 
+`device.ipRegionCode`, `device.ipCountry`, `device.ipCity`, `device.ipContinent`, or `device.ipTimezone`.
+
 ## 1.1.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 - SW-2833: Adds support for dark mode paywall background color.
 -  Adds ability to target devices based on their IP address location. Use `device.ipRegion`, 
 `device.ipRegionCode`, `device.ipCountry`, `device.ipCity`, `device.ipContinent`, or `device.ipTimezone`.
+- Adds `event_name` to the event params for use with audience filters.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 -  Adds ability to target devices based on their IP address location. Use `device.ipRegion`, 
 `device.ipRegionCode`, `device.ipCountry`, `device.ipCity`, `device.ipContinent`, or `device.ipTimezone`.
 
+### Fixes
+
+- Fixes issue with products whose labels weren't primary/secondary/tertiary.
+
 ## 1.1.5
 
 ### Fixes

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("signing")
 }
 
-version = "1.1.5"
+version = "1.1.6"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -37,7 +37,8 @@ sealed class TrackingLogic {
 
             val eventParams: MutableMap<String, Any> = mutableMapOf(
                 "\$is_standard_event" to isStandardEvent,
-                "\$event_name" to eventName
+                "\$event_name" to eventName,
+                "event_name" to eventName
             )
 
             // Filter then assign Superwall parameters

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -142,6 +142,16 @@ class DependencyContainer(
             factory = this,
         )
 
+        val options = options ?: SuperwallOptions()
+        api = Api(networkEnvironment = options.networkEnvironment)
+
+        deviceHelper = DeviceHelper(
+            context = context,
+            storage = storage,
+            network = network,
+            factory = this
+        )
+
         configManager = ConfigManager(
             context = context,
             storeKitManager = storeKitManager,
@@ -149,12 +159,9 @@ class DependencyContainer(
             network = network,
             options = options,
             factory = this,
-            paywallManager = paywallManager
+            paywallManager = paywallManager,
+            deviceHelper = deviceHelper
         )
-
-        api = Api(networkEnvironment = configManager.options.networkEnvironment)
-
-        deviceHelper = DeviceHelper(context = context, storage = storage, factory = this)
 
         eventsQueue = EventsQueue(context, configManager = configManager, network = network)
 

--- a/superwall/src/main/java/com/superwall/sdk/models/geo/GeoInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/geo/GeoInfo.kt
@@ -1,0 +1,17 @@
+package com.superwall.sdk.models.geo
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GeoInfo(
+    val city: String?,
+    val country: String?,
+    val longitude: Double?,
+    val latitude: Double?,
+    val region: String?,
+    val regionCode: String?,
+    val continent: String?,
+    val metroCode: String?,
+    val postalCode: String?,
+    val timezone: String?
+)

--- a/superwall/src/main/java/com/superwall/sdk/models/geo/GeoWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/geo/GeoWrapper.kt
@@ -1,0 +1,11 @@
+package com.superwall.sdk.models.geo
+
+import com.superwall.sdk.models.SerializableEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GeoWrapper(
+    @SerialName("geoInfo")
+    val info: GeoInfo
+): SerializableEntity

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -50,6 +50,7 @@ data class Paywall(
     private val presentationCondition: String,
 
     val backgroundColorHex: String,
+    val darkBackgroundColorHex: String? = null,
 
     // Declared as private to prevent direct access
     @kotlinx.serialization.Transient()
@@ -128,6 +129,20 @@ data class Paywall(
                         "Defaulting to white."
             )
             Color.WHITE
+        }
+    }
+
+    val darkBackgroundColor: Int? by lazy {
+        try {
+            Color.parseColor(this.darkBackgroundColorHex)
+        } catch (e: Throwable) {
+            Logger.debug(
+                logLevel = LogLevel.warn,
+                scope = LogScope.paywallViewController,
+                message = "Invalid paywall background color: ${this.darkBackgroundColorHex}. " +
+                        "Defaulting to white."
+            )
+            null
         }
     }
 
@@ -233,6 +248,7 @@ data class Paywall(
                 presentationStyle = "MODAL",
                 presentationCondition = "CHECK_USER_SUBSCRIPTION",
                 backgroundColorHex = "000000",
+                darkBackgroundColorHex = null,
                 productIds = arrayListOf(),
                 _productItems = emptyList(),
                 _products = emptyList(),

--- a/superwall/src/main/java/com/superwall/sdk/network/API.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/API.kt
@@ -6,7 +6,8 @@ import com.superwall.sdk.config.options.SuperwallOptions
 data class Api(
     val hostDomain: String,
     val base: Base,
-    val collector: Collector
+    val collector: Collector,
+    val geo: Geo
 ) {
     companion object {
         const val version1 = "/api/v1/"
@@ -18,7 +19,8 @@ data class Api(
     constructor(networkEnvironment: SuperwallOptions.NetworkEnvironment) : this(
         hostDomain = networkEnvironment.hostDomain,
         base = Base(networkEnvironment),
-        collector = Collector(networkEnvironment)
+        collector = Collector(networkEnvironment),
+        geo = Geo(networkEnvironment)
     )
 
     data class Base(private val networkEnvironment: SuperwallOptions.NetworkEnvironment) {
@@ -31,5 +33,11 @@ data class Api(
         val host: String
             //            get() = "10.0.2.2:9909"
             get() = networkEnvironment.collectorHost
+    }
+
+    data class Geo(private val networkEnvironment: SuperwallOptions.NetworkEnvironment) {
+        val host: String
+            //            get() = "10.0.2.2:9909"
+            get() = "geo-api.superwall.com"
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
@@ -8,6 +8,7 @@ import com.superwall.sdk.models.config.Config
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.events.EventsRequest
 import com.superwall.sdk.models.events.EventsResponse
+import com.superwall.sdk.models.geo.GeoWrapper
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.paywall.Paywalls
 import com.superwall.sdk.models.postback.PostBackResponse
@@ -193,6 +194,18 @@ data class Endpoint<Response : SerializableEntity>(
                 ),
                 method = HttpMethod.GET,
                 isForDebugging = true,
+                factory = factory
+            )
+        }
+
+        fun geo(factory: ApiFactory): Endpoint<GeoWrapper> {
+            val geoHost = factory.api.geo.host
+            return Endpoint(
+                components = Components(
+                    host = geoHost,
+                    path = Api.version1 + "geo"
+                ),
+                method = HttpMethod.GET,
                 factory = factory
             )
         }

--- a/superwall/src/main/java/com/superwall/sdk/network/Network.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Network.kt
@@ -11,6 +11,7 @@ import com.superwall.sdk.models.config.Config
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.events.EventsRequest
 import com.superwall.sdk.models.events.EventsResponse
+import com.superwall.sdk.models.geo.GeoInfo
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.network.session.CustomHttpUrlConnection
 import kotlinx.coroutines.flow.filter
@@ -154,7 +155,7 @@ open class Network(
             val paywalls = urlSession.request(
                 Endpoint.paywalls(factory = factory)
             )
-            return paywalls.paywalls
+            paywalls.paywalls
         } catch (error: Throwable) {
             Logger.debug(
                 logLevel = LogLevel.error,
@@ -163,6 +164,23 @@ open class Network(
                 error = error
             )
             throw error
+        }
+    }
+
+    suspend fun getGeoInfo(): GeoInfo? {
+        return try {
+            val geoWrapper = urlSession.request(
+                Endpoint.geo(factory = factory)
+            )
+            geoWrapper.info
+        } catch (error: Exception) {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.network,
+                message = "Request Failed: /geo",
+                error = error
+            )
+            null
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
@@ -2,7 +2,6 @@ package com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator
 
 import android.content.Context
 import android.webkit.ConsoleMessage
-import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.javascriptengine.JavaScriptSandbox
@@ -110,8 +109,16 @@ class ExpressionEvaluator(
         rule: TriggerRule
     ): TriggerRuleOutcome = withContext(singleThreadContext) {
         val jsIsolate = jsSandbox?.createIsolate()
+        jsIsolate?.addOnTerminatedCallback {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.superwallCore,
+                message = "$it"
+            )
+        }
 
         val resultFuture = jsIsolate?.evaluateJavaScriptAsync("$SDKJS\n $base64Params")
+
         val result = resultFuture?.await()
         jsIsolate?.close()
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -8,6 +8,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
 import android.os.Build
@@ -180,6 +181,19 @@ class PaywallViewController(
     private var unsavedOccurrence: TriggerRuleOccurrence? = null
 
     private val cacheKey: String = PaywallCacheLogic.key(paywall.identifier, deviceHelper.locale)
+
+    private val backgroundColor: Int
+        get() {
+            val style = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+            } else {
+                Configuration.UI_MODE_NIGHT_UNDEFINED
+            }
+            return when (style) {
+                Configuration.UI_MODE_NIGHT_YES -> paywall.darkBackgroundColor ?: paywall.backgroundColor
+                else ->  paywall.backgroundColor
+            }
+        }
     //endregion
 
     //region Initialization
@@ -191,7 +205,6 @@ class PaywallViewController(
         id = View.generateViewId()
 
         // Add the shimmer view and hide it
-        val backgroundColor = paywall.backgroundColor
         this.shimmerView = ShimmerView(
             context,
             backgroundColor,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
@@ -22,7 +22,7 @@ object TemplateLogic {
     ): String {
         val productsTemplate = ProductTemplate(
             eventName = "products",
-            products = paywall.products
+            products = paywall.productItems
         )
 
         val variablesTemplate = factory.makeJsonVariables(

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
@@ -48,7 +48,13 @@ data class DeviceTemplate(
     val sdkVersionPadded: String,
     val appBuildString: String,
     val appBuildStringNumber: Int?,
-    val interfaceStyleMode: String
+    val interfaceStyleMode: String,
+    val ipRegion: String?,
+    val ipRegionCode: String?,
+    val ipCountry: String?,
+    val ipCity: String?,
+    val ipContinent: String?,
+    val ipTimezone: String?
 ) {
     fun toDictionary(): Map<String, Any> {
         val json = Json { encodeDefaults = true }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/ProductTemplate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/ProductTemplate.kt
@@ -1,6 +1,6 @@
 package com.superwall.sdk.paywall.view_controller.web_view.templating.models
 
-import com.superwall.sdk.models.product.Product
+import com.superwall.sdk.models.product.ProductItem
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,5 +9,5 @@ import kotlinx.serialization.Serializable
 data class ProductTemplate(
     @SerialName("event_name")
     val eventName: String,
-    val products: List<Product>
+    val products: List<ProductItem>
 )


### PR DESCRIPTION
### Enhancements

- SW-2833: Adds support for dark mode paywall background color.
-  Adds ability to target devices based on their IP address location. Use `device.ipRegion`, 
`device.ipRegionCode`, `device.ipCountry`, `device.ipCity`, `device.ipContinent`, or `device.ipTimezone`.
- Adds `event_name` to the event params for use with audience filters.

### Fixes

- Fixes issue with products whose labels weren't primary/secondary/tertiary.