### PR TITLE
Add transaction restoration events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.1.7
+
+### Enhancements
+- Adds `restore_start`, `restore_complete`, and `restore_fail` events.
+
+
 ## 1.1.6
 
 ### Enhancements

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("signing")
 }
 
-version = "1.1.6"
+version = "1.1.7"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -72,12 +72,14 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
         val selectedOption: SurveyOption,
         val customResponse: String?,
         val paywallInfo: PaywallInfo
-    ) : InternalSuperwallEvent(SuperwallEvent.SurveyResponse(
-        survey,
-        selectedOption,
-        customResponse,
-        paywallInfo
-    )) {
+    ) : InternalSuperwallEvent(
+        SuperwallEvent.SurveyResponse(
+            survey,
+            selectedOption,
+            customResponse,
+            paywallInfo
+        )
+    ) {
         override val superwallEvent: SuperwallEvent
             get() = SuperwallEvent.SurveyResponse(
                 survey, selectedOption, customResponse, paywallInfo
@@ -102,7 +104,6 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             return paywallInfo.eventParams(otherParams = params)
         }
     }
-
 
 
     class AppLaunch(override var customParameters: HashMap<String, Any> = HashMap()) :
@@ -150,10 +151,18 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                 uri.queryParameterNames.forEach { paramName ->
                     val paramValue = uri.getQueryParameter(paramName) ?: return@forEach
                     when {
-                        paramValue.equals("true", ignoreCase = true) -> queryStrings[paramName] = true
-                        paramValue.equals("false", ignoreCase = true) -> queryStrings[paramName] = false
-                        paramValue.toIntOrNull() != null -> queryStrings[paramName] = paramValue.toInt()
-                        paramValue.toDoubleOrNull() != null -> queryStrings[paramName] = paramValue.toDouble()
+                        paramValue.equals("true", ignoreCase = true) -> queryStrings[paramName] =
+                            true
+
+                        paramValue.equals("false", ignoreCase = true) -> queryStrings[paramName] =
+                            false
+
+                        paramValue.toIntOrNull() != null -> queryStrings[paramName] =
+                            paramValue.toInt()
+
+                        paramValue.toDoubleOrNull() != null -> queryStrings[paramName] =
+                            paramValue.toDouble()
+
                         else -> queryStrings[paramName] = paramValue
                     }
                 }
@@ -189,13 +198,16 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                 is State.Start -> SuperwallEvent.PaywallResponseLoadStart(
                     eventData?.name
                 )
+
                 is State.Complete -> SuperwallEvent.PaywallResponseLoadComplete(
                     eventData?.name,
                     state.paywallInfo
                 )
+
                 is State.Fail -> SuperwallEvent.PaywallResponseLoadFail(
                     eventData?.name
                 )
+
                 is State.NotFound -> SuperwallEvent.PaywallResponseLoadNotFound(
                     eventData?.name
                 )
@@ -268,7 +280,8 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                 "trigger_name" to triggerName
             )
 
-            val triggerSessionId = sessionEventsManager.triggerSession.getActiveTriggerSession()?.sessionId
+            val triggerSessionId =
+                sessionEventsManager.triggerSession.getActiveTriggerSession()?.sessionId
             if (triggerSessionId != null) {
                 params["trigger_session_id"] = triggerSessionId
             }
@@ -279,6 +292,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                         this["result"] = "no_rule_match"
                     }
                 }
+
                 is InternalTriggerResult.Holdout -> {
                     params.apply {
                         this["variant_id"] = triggerResult.experiment.variant.id
@@ -286,6 +300,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                         this["result"] = "holdout"
                     }
                 }
+
                 is InternalTriggerResult.Paywall -> {
                     params.apply {
                         this["variant_id"] = triggerResult.experiment.variant.id
@@ -295,11 +310,13 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                         this["result"] = "present"
                     }
                 }
+
                 is InternalTriggerResult.EventNotFound -> {
                     params.apply {
                         this["result"] = "eventNotFound"
                     }
                 }
+
                 is InternalTriggerResult.Error -> {
                     params.apply {
                         this["result"] = "error"
@@ -322,7 +339,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             reason = statusReason
         )
     ) {
-        interface Factory: RuleAttributesFactory, FeatureFlagsFactory,
+        interface Factory : RuleAttributesFactory, FeatureFlagsFactory,
             ComputedPropertyRequestsFactory {}
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> {
@@ -342,6 +359,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             get() {
                 return paywallInfo.customParams()
             }
+
         override suspend fun getSuperwallParameters(): HashMap<String, Any> {
             return HashMap(paywallInfo.eventParams())
         }
@@ -396,6 +414,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             class Abandon(val product: StoreProduct) : State()
             class Complete(val product: StoreProduct, val transaction: StoreTransactionType?) :
                 State()
+
             class Restore(val restoreType: RestoreType) : State()
             class Timeout : State()
         }
@@ -411,23 +430,28 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                     product = state.product,
                     paywallInfo = paywallInfo
                 )
+
                 is State.Fail -> SuperwallEvent.TransactionFail(
                     error = state.error,
                     paywallInfo = paywallInfo
                 )
+
                 is State.Abandon -> SuperwallEvent.TransactionAbandon(
                     product = state.product,
                     paywallInfo = paywallInfo
                 )
+
                 is State.Complete -> SuperwallEvent.TransactionComplete(
                     transaction = state.transaction,
                     product = state.product,
                     paywallInfo = paywallInfo
                 )
+
                 is State.Restore -> SuperwallEvent.TransactionRestore(
                     restoreType = state.restoreType,
                     paywallInfo = paywallInfo
                 )
+
                 is State.Timeout -> SuperwallEvent.TransactionTimeout(paywallInfo = paywallInfo)
             }
         override val rawName: String
@@ -446,6 +470,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                     eventParams["restore_via_purchase_attempt"] = model != null
                     return eventParams
                 }
+
                 is State.Start,
                 is State.Abandon,
                 is State.Complete,
@@ -456,12 +481,18 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                     }
                     return eventParams
                 }
+
                 is State.Fail -> {
                     when (state.error) {
                         is TransactionError.Failure,
                         is TransactionError.Pending -> {
                             val message = state.error.message
-                            var eventParams = HashMap(paywallInfo.eventParams(product, otherParams = mapOf("message" to message)))
+                            var eventParams = HashMap(
+                                paywallInfo.eventParams(
+                                    product,
+                                    otherParams = mapOf("message" to message)
+                                )
+                            )
                             return eventParams
                         }
                     }
@@ -547,12 +578,15 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                 is PaywallWebviewLoad.State.Start -> SuperwallEvent.PaywallWebviewLoadStart(
                     paywallInfo
                 )
+
                 is PaywallWebviewLoad.State.Timeout -> SuperwallEvent.PaywallWebviewLoadTimeout(
                     paywallInfo
                 )
+
                 is PaywallWebviewLoad.State.Fail -> SuperwallEvent.PaywallWebviewLoadFail(
                     paywallInfo
                 )
+
                 is PaywallWebviewLoad.State.Complete -> SuperwallEvent.PaywallWebviewLoadComplete(
                     paywallInfo
                 )
@@ -590,11 +624,13 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                     eventData?.name,
                     paywallInfo
                 )
+
                 is State.Fail -> SuperwallEvent.PaywallProductsLoadFail(
                     state.errorMessage,
                     eventData?.name,
                     paywallInfo
                 )
+
                 is State.Complete -> SuperwallEvent.PaywallProductsLoadComplete(
                     eventData?.name,
                     paywallInfo
@@ -618,6 +654,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                         params["error_message"] = state.errorMessage
                     }
                 }
+
                 else -> Unit
             }
 
@@ -626,10 +663,44 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
         }
     }
 
+    data class Restore(
+        val state: State,
+        val paywallInfo: PaywallInfo
+    ) : InternalSuperwallEvent(
+        when (state) {
+            is State.Complete -> SuperwallEvent.Restore.Complete
+            is State.Failure -> SuperwallEvent.Restore.Fail(state.reason)
+            is State.Start -> SuperwallEvent.Restore.Start
+        }
+    ) {
+
+        sealed class State {
+            object Start : State()
+            data class Failure(val reason: String) : State()
+            object Complete : State()
+
+        }
+
+        override val customParameters: Map<String, Any>
+            get() = paywallInfo.customParams().let {
+                when (state) {
+                    is State.Failure -> it + mapOf("error_message" to state.reason)
+                    else -> it
+                }
+            }
+
+        override suspend fun getSuperwallParameters(): HashMap<String, Any> {
+            return HashMap()
+        }
+    }
+
 
 }
 
 fun test() {
     InternalSuperwallEvent.AppOpen()
-    InternalSuperwallEvent.AppInstall(appInstalledAtString = "test", hasExternalPurchaseController = false)
+    InternalSuperwallEvent.AppInstall(
+        appInstalledAtString = "test",
+        hasExternalPurchaseController = false
+    )
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -681,26 +681,16 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
 
         }
 
-        override val customParameters: Map<String, Any>
-            get() = paywallInfo.customParams().let {
+        override suspend fun getSuperwallParameters(): Map<String, Any> =
+            paywallInfo.eventParams().let {
                 when (state) {
                     is State.Failure -> it + mapOf("error_message" to state.reason)
                     else -> it
                 }
             }
 
-        override suspend fun getSuperwallParameters(): HashMap<String, Any> {
-            return HashMap()
-        }
+        override val customParameters: Map<String, Any>
+            get() = paywallInfo.customParams()
+
     }
-
-
-}
-
-fun test() {
-    InternalSuperwallEvent.AppOpen()
-    InternalSuperwallEvent.AppInstall(
-        appInstalledAtString = "test",
-        hasExternalPurchaseController = false
-    )
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -175,6 +175,23 @@ sealed class SuperwallEvent {
             get() = "transaction_restore"
     }
 
+
+    /// State of transaction restoration
+    sealed class Restore : SuperwallEvent() {
+        object Start : Restore(){
+            override val rawName: String
+                get() = "restore_start"
+        }
+        data class Fail(val reason: String) : Restore(){
+            override val rawName: String
+                get() = "restore_fail"
+        }
+        object Complete : Restore(){
+            override val rawName: String
+                get() = "restore_complete"
+        }
+    }
+
     /// When the transaction took > 5 seconds to show the payment sheet.
     data class TransactionTimeout(val paywallInfo: PaywallInfo) : SuperwallEvent() {
         override val rawName: String
@@ -293,6 +310,7 @@ sealed class SuperwallEvent {
         override val rawName: String
             get() = "survey_response"
     }
+
 
     /// When the user chose the close button on a survey instead of responding.
     class SurveyClose() : SuperwallEvent() {

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -353,13 +353,13 @@ class TransactionManager(
             didRestore(paywallViewController = paywallViewController)
         } else {
 
-            val msg = "Transactions Failed to Restore,${
+            val msg = "Transactions Failed to Restore: ${
                 if (hasRestored && !isUserSubscribed) {
-                    " The user's subscription status is \"inactive\", but the restoration result is \"restored\"." +
+                    "The user's subscription status is \"inactive\", but the restoration result is \"restored\"." +
                             " Ensure the subscription status is active before confirming successful restoration."
-                } else "Original restoration error message: ${
+                } else " Original restoration error message: ${
                     when (restorationResult) {
-                        is RestorationResult.Failed -> restorationResult.error?.stackTraceToString()
+                        is RestorationResult.Failed -> restorationResult.error?.localizedMessage
                         else -> null
                     }
                 }"

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -29,7 +29,11 @@ import com.superwall.sdk.storage.EventsQueue
 import com.superwall.sdk.store.StoreKitManager
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TransactionManager(
     private val storeKitManager: StoreKitManager,
@@ -40,8 +44,9 @@ class TransactionManager(
     private val factory: Factory,
     private val context: Context
 ) {
-    interface Factory: OptionsFactory, TriggerFactory, TransactionVerifierFactory,
+    interface Factory : OptionsFactory, TriggerFactory, TransactionVerifierFactory,
         StoreTransactionFactory, DeviceHelperFactory {}
+
     private var lastPaywallViewController: PaywallViewController? = null
 
     suspend fun purchase(
@@ -67,17 +72,21 @@ class TransactionManager(
             is PurchaseResult.Purchased -> {
                 didPurchase(product, paywallViewController)
             }
+
             is PurchaseResult.Restored -> {
                 didRestore(
                     product = product,
                     paywallViewController = paywallViewController
                 )
             }
+
             is PurchaseResult.Failed -> {
                 val superwallOptions = factory.makeSuperwallOptions()
-                val shouldShowPurchaseFailureAlert = superwallOptions.paywalls.shouldShowPurchaseFailureAlert
+                val shouldShowPurchaseFailureAlert =
+                    superwallOptions.paywalls.shouldShowPurchaseFailureAlert
                 val triggers = factory.makeTriggers()
-                val transactionFailExists = triggers.contains(SuperwallEventObjc.TransactionFail.rawName)
+                val transactionFailExists =
+                    triggers.contains(SuperwallEventObjc.TransactionFail.rawName)
 
                 if (shouldShowPurchaseFailureAlert && !transactionFailExists) {
                     trackFailure(
@@ -99,9 +108,11 @@ class TransactionManager(
                     return paywallViewController.togglePaywallSpinner(isHidden = true)
                 }
             }
+
             is PurchaseResult.Pending -> {
                 handlePendingTransaction(paywallViewController)
             }
+
             is PurchaseResult.Cancelled -> {
                 trackCancelled(product, paywallViewController)
             }
@@ -163,7 +174,12 @@ class TransactionManager(
         CoroutineScope(Dispatchers.Default).launch {
             val paywallInfo = paywallViewController.info
             val trackedEvent = InternalSuperwallEvent.Transaction(
-                state =  InternalSuperwallEvent.Transaction.State.Fail(TransactionError.Failure(errorMessage, product)),
+                state = InternalSuperwallEvent.Transaction.State.Fail(
+                    TransactionError.Failure(
+                        errorMessage,
+                        product
+                    )
+                ),
                 paywallInfo = paywallInfo,
                 product = product,
                 model = null
@@ -310,10 +326,17 @@ class TransactionManager(
 
         paywallViewController.loadingState = PaywallLoadingState.LoadingPurchase()
 
+        Superwall.instance.track(
+            InternalSuperwallEvent.Restore(
+                state = InternalSuperwallEvent.Restore.State.Start,
+                paywallInfo = paywallViewController.info
+            )
+        )
         val restorationResult = purchaseController.restorePurchases()
 
         val hasRestored = restorationResult is RestorationResult.Restored
-        val isUserSubscribed = Superwall.instance.subscriptionStatus.value == SubscriptionStatus.ACTIVE
+        val isUserSubscribed =
+            Superwall.instance.subscriptionStatus.value == SubscriptionStatus.ACTIVE
 
         if (hasRestored && isUserSubscribed) {
             Logger.debug(
@@ -321,13 +344,39 @@ class TransactionManager(
                 scope = LogScope.paywallTransactions,
                 message = "Transactions Restored"
             )
+            Superwall.instance.track(
+                InternalSuperwallEvent.Restore(
+                    state = InternalSuperwallEvent.Restore.State.Complete,
+                    paywallInfo = paywallViewController.info
+                )
+            )
             didRestore(paywallViewController = paywallViewController)
         } else {
+
+            val msg = "Transactions Failed to Restore,${
+                if (hasRestored && !isUserSubscribed) {
+                    " The user's subscription status is \"inactive\", but the restoration result is \"restored\"." +
+                            " Ensure the subscription status is active before confirming successful restoration."
+                } else "Original restoration error message: ${
+                    when (restorationResult) {
+                        is RestorationResult.Failed -> restorationResult.error?.stackTraceToString()
+                        else -> null
+                    }
+                }"
+            }"
+
             Logger.debug(
                 logLevel = LogLevel.debug,
                 scope = LogScope.paywallTransactions,
-                message = "Transactions Failed to Restore"
+                message = msg
             )
+            Superwall.instance.track(
+                InternalSuperwallEvent.Restore(
+                    state = InternalSuperwallEvent.Restore.State.Failure(msg),
+                    paywallInfo = paywallViewController.info
+                )
+            )
+
 
             paywallViewController.presentAlert(
                 title = Superwall.instance.options.paywalls.restoreFailed.title,
@@ -411,7 +460,9 @@ class TransactionManager(
 
                 val notifications =
                     paywallInfo.localNotifications.filter { it.type == LocalNotificationType.TrialStarted }
-                val paywallActivity = paywallViewController.encapsulatingActivity as? SuperwallPaywallActivity ?: return
+                val paywallActivity =
+                    paywallViewController.encapsulatingActivity as? SuperwallPaywallActivity
+                        ?: return
                 paywallActivity.attemptToScheduleNotifications(
                     notifications = notifications,
                     factory = factory,

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -353,9 +353,9 @@ class TransactionManager(
             didRestore(paywallViewController = paywallViewController)
         } else {
 
-            val msg = "Transactions Failed to Restore: ${
+            val msg = "Transactions Failed to Restore.${
                 if (hasRestored && !isUserSubscribed) {
-                    "The user's subscription status is \"inactive\", but the restoration result is \"restored\"." +
+                    " The user's subscription status is \"inactive\", but the restoration result is \"restored\"." +
                             " Ensure the subscription status is active before confirming successful restoration."
                 } else " Original restoration error message: ${
                     when (restorationResult) {


### PR DESCRIPTION
## Changes in this pull request

Adds `restore_start`, `restore_complete`, and `restore_fail` events to tracking.

## 

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.