### PR TITLE
Expose presentation info property through paywall info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ### Enhancements
 - Adds `restore_start`, `restore_complete`, and `restore_fail` events.
+- SW-2805: Exposes a `presentation` property on the `PaywallInfo` object. This contains information about the presentation of the paywall.
 
 
 ## 1.1.6

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -38,12 +38,6 @@ data class Paywall(
     val url: @Serializable(with = URLSerializer::class) URL,
     @SerialName("paywalljs_event")
     val htmlSubstitutions: String,
-    @kotlinx.serialization.Transient()
-    var presentation: PaywallPresentationInfo = PaywallPresentationInfo(
-        PaywallPresentationStyle.MODAL,
-        PresentationCondition.ALWAYS,
-    ),
-
     @SerialName("presentation_style_v2")
     private val presentationStyle: String,
 
@@ -51,6 +45,13 @@ data class Paywall(
     private val presentationDelay: Long,
 
     private val presentationCondition: String,
+
+    @kotlinx.serialization.Transient()
+    var presentation: PaywallPresentationInfo = PaywallPresentationInfo(
+        style = PaywallPresentationStyle.valueOf(presentationStyle.uppercase()),
+        condition = PresentationCondition.valueOf(presentationCondition.uppercase()),
+        delay = presentationDelay
+    ),
 
     val backgroundColorHex: String,
     val darkBackgroundColorHex: String? = null,
@@ -151,11 +152,6 @@ data class Paywall(
 
     init {
         productItems = _productItems
-        presentation = PaywallPresentationInfo(
-            style = PaywallPresentationStyle.valueOf(presentationStyle.uppercase()),
-            condition = PresentationCondition.valueOf(presentationCondition.uppercase()),
-            loadingDelay = presentationDelay
-        )
     }
 
 

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -39,13 +39,16 @@ data class Paywall(
     @SerialName("paywalljs_event")
     val htmlSubstitutions: String,
     @kotlinx.serialization.Transient()
-    var presentation: Presentation = Presentation(
+    var presentation: PaywallPresentationInfo = PaywallPresentationInfo(
         PaywallPresentationStyle.MODAL,
-        PresentationCondition.ALWAYS
+        PresentationCondition.ALWAYS,
     ),
 
     @SerialName("presentation_style_v2")
     private val presentationStyle: String,
+
+    @SerialName("presentation_delay")
+    private val presentationDelay: Long,
 
     private val presentationCondition: String,
 
@@ -148,17 +151,13 @@ data class Paywall(
 
     init {
         productItems = _productItems
-        presentation = Presentation(
+        presentation = PaywallPresentationInfo(
             style = PaywallPresentationStyle.valueOf(presentationStyle.uppercase()),
-            condition = PresentationCondition.valueOf(presentationCondition.uppercase())
+            condition = PresentationCondition.valueOf(presentationCondition.uppercase()),
+            loadingDelay = presentationDelay
         )
     }
 
-    @Serializable
-    data class Presentation(
-        val style: PaywallPresentationStyle,
-        val condition: PresentationCondition
-    )
 
     @Serializable
     data class LoadingInfo(
@@ -209,7 +208,8 @@ data class Paywall(
             closeReason = closeReason,
             localNotifications = localNotifications,
             computedPropertyRequests = computedPropertyRequests,
-            surveys = surveys
+            surveys = surveys,
+            presentation = presentation
         )
     }
 
@@ -241,9 +241,10 @@ data class Paywall(
                 name = "abac",
                 url = URL("https://google.com"),
                 htmlSubstitutions = "",
-                presentation = Presentation(
+                presentation = PaywallPresentationInfo(
                     PaywallPresentationStyle.MODAL,
-                    PresentationCondition.CHECK_USER_SUBSCRIPTION
+                    PresentationCondition.CHECK_USER_SUBSCRIPTION,
+                    300
                 ),
                 presentationStyle = "MODAL",
                 presentationCondition = "CHECK_USER_SUBSCRIPTION",
@@ -260,7 +261,8 @@ data class Paywall(
                 paywalljsVersion = "",
                 isFreeTrialAvailable = false,
                 featureGating = FeatureGatingBehavior.NonGated,
-                localNotifications = arrayListOf()
+                localNotifications = arrayListOf(),
+                presentationDelay = 300
             )
 
         }

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
@@ -12,5 +12,5 @@ data class PaywallPresentationInfo(
 
     // The delay in milliseconds before switching from the loading view to
     // the paywall view.
-    val loadingDelay: Long? = null
+    val delay: Long
 )

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
@@ -1,15 +1,20 @@
 package com.superwall.sdk.models.paywall
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class PaywallPresentationInfo(
+
+    @SerialName("style")
     // The presentation style of the paywall
     val style: PaywallPresentationStyle,
 
+    @SerialName("condition")
     // The condition for when a paywall should present.
     val condition: PresentationCondition,
 
+    @SerialName("delay")
     // The delay in milliseconds before switching from the loading view to
     // the paywall view.
     val delay: Long

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationInfo.kt
@@ -1,0 +1,16 @@
+package com.superwall.sdk.models.paywall
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PaywallPresentationInfo(
+    // The presentation style of the paywall
+    val style: PaywallPresentationStyle,
+
+    // The condition for when a paywall should present.
+    val condition: PresentationCondition,
+
+    // The delay in milliseconds before switching from the loading view to
+    // the paywall view.
+    val loadingDelay: Long? = null
+)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -10,6 +10,10 @@ import com.superwall.sdk.misc.camelCaseToSnakeCase
 import com.superwall.sdk.models.config.FeatureGatingBehavior
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.paywall.LocalNotification
+import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.models.paywall.PaywallPresentationInfo
+import com.superwall.sdk.models.paywall.PaywallPresentationStyle
+import com.superwall.sdk.models.paywall.PresentationCondition
 import com.superwall.sdk.models.product.Product
 import com.superwall.sdk.models.product.ProductItem
 import com.superwall.sdk.models.serialization.URLSerializer
@@ -18,7 +22,7 @@ import com.superwall.sdk.store.abstractions.product.StoreProduct
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.net.URL
-import java.util.*
+import java.util.Date
 
 
 @Serializable
@@ -62,7 +66,8 @@ data class PaywallInfo(
     val localNotifications: List<LocalNotification>,
     val computedPropertyRequests: List<ComputedPropertyRequest>,
     val surveys: List<Survey>,
-    val factory: TriggerSessionManagerFactory
+    val factory: TriggerSessionManagerFactory,
+    val presentation: PaywallPresentationInfo
 ) {
     constructor(
         databaseId: String,
@@ -92,7 +97,8 @@ data class PaywallInfo(
         localNotifications: List<LocalNotification>,
         computedPropertyRequests: List<ComputedPropertyRequest>,
         closeReason: PaywallCloseReason,
-        surveys: List<Survey>
+        surveys: List<Survey>,
+        presentation: PaywallPresentationInfo
     ) : this(
         databaseId = databaseId,
         identifier = identifier,
@@ -139,7 +145,8 @@ data class PaywallInfo(
         localNotifications = localNotifications,
         computedPropertyRequests = computedPropertyRequests,
         closeReason = closeReason,
-        surveys = surveys
+        surveys = surveys,
+        presentation = presentation
     )
 
     fun eventParams(
@@ -211,7 +218,8 @@ data class PaywallInfo(
 
     /// Parameters that can be used in rules.
     fun customParams(): MutableMap<String, Any> {
-        val featureGatingSerialized = Json {}.encodeToString(FeatureGatingBehavior.serializer(), featureGatingBehavior)
+        val featureGatingSerialized =
+            Json {}.encodeToString(FeatureGatingBehavior.serializer(), featureGatingBehavior)
 
         val output: MutableMap<String, Any?> = mutableMapOf(
             "paywall_id" to databaseId,


### PR DESCRIPTION
## Changes in this pull request

* Adds `presentation` property to `PaywallInfo`, containing `PaywallPresentationInfo` (style, condition, loading delay).
* Adds loading `delay` property to `Paywall` and `PaywallInfo`
* Uses `delay` property to wait with rendering when loading paywall in webview

## 

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

