### PR TITLE
Fix abandoning transaction preventing us from restarting the transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ### Enhancements
 - Adds `restore_start`, `restore_complete`, and `restore_fail` events.
 - SW-2805: Exposes a `presentation` property on the `PaywallInfo` object. This contains information about the presentation of the paywall.
+- Fixes `SW-2854` where abandoning transaction by pressing back would prevent restarting the transaction
 
 
 ## 1.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## 1.1.7
 
 ### Enhancements
-- Adds `restore_start`, `restore_complete`, and `restore_fail` events.
 - SW-2805: Exposes a `presentation` property on the `PaywallInfo` object. This contains information about the presentation of the paywall.
+- Fixes `SW-2855` by adding `restore_start`, `restore_complete`, and `restore_fail` events.
 - Fixes `SW-2854` where abandoning transaction by pressing back would prevent restarting the transaction
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## 1.1.7
 
 ### Enhancements
+
 - SW-2805: Exposes a `presentation` property on the `PaywallInfo` object. This contains information about the presentation of the paywall.
-- Fixes `SW-2855` by adding `restore_start`, `restore_complete`, and `restore_fail` events.
-- Fixes `SW-2854` where abandoning transaction by pressing back would prevent restarting the transaction
+- SW-2855: Adds `restore_start`, `restore_complete`, and `restore_fail` events.
+
+### Fixes
+
+- SW-2854: Fixed issue where abandoning the transaction by pressing back would prevent the user from restarting the transaction.
 
 
 ## 1.1.6

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -114,6 +114,10 @@ class ExternalNativePurchaseController(var context: Context) : PurchaseControlle
         basePlanId: String?,
         offerId: String?
     ): PurchaseResult {
+
+        //Clear previous purchase results to avoid emitting old results
+        purchaseResults.value = null
+
         val fullId = buildFullId(
             subscriptionId = productDetails.productId,
             basePlanId = basePlanId,


### PR DESCRIPTION
## Changes in this pull request

* Fixes `SW-2854` where `transaction_abandoned` prevented restarting the transaction by clearing the abandoned state of previous purchase from `purchaseResults`

## 

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

