### PR TITLE
Update dependency chain & coroutines to fix issues with stateflow initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.1.8
+
+### Enhancements
+
+- Toolchain and dependency updates
+
+### Fixes
+
+- SW-2863: Fixed a `NullPointerException` some users on Android 12 & 13 would experience when calling `configure`.
+
 ## 1.1.7
 
 ### Enhancements
@@ -12,7 +22,6 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ### Fixes
 
 - SW-2854: Fixed issue where abandoning the transaction by pressing back would prevent the user from restarting the transaction.
-- SW-2863: Fixed a `NullPointerException` some users on Android 12 & 13 would experience when calling `configure`.
 
 ## 1.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ### Fixes
 
 - SW-2854: Fixed issue where abandoning the transaction by pressing back would prevent the user from restarting the transaction.
-
+- SW-2863: Fixed a `NullPointerException` some users on Android 12 & 13 would experience when calling `configure`.
 
 ## 1.1.6
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.8.21"
+    alias(libs.plugins.serialization)
 }
 
 android {
@@ -39,7 +39,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = "1.5.0"
     }
     packagingOptions {
         resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,6 @@
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.serialization) apply false
 }
 true

--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = "1.5.0"
     }
     packagingOptions {
         resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,31 +1,46 @@
 [versions]
 billing_version = "6.1.0"
 browser_version = "1.5.0"
-gradle_plugin_version = "7.4.2"
+gradle_plugin_version = "8.4.1"
+javascriptengineVersion = "1.0.0-beta01"
+kotlinxCoroutinesGuavaVersion = "1.8.1"
+lifecycleProcessVersion = "2.8.1"
 mockk = "1.13.8"
 revenue_cat_version = "7.7.1"
-compose_version = "2022.10.00"
-kotlinx_serialization_json_version = "1.5.1"
+compose_version = "2024.05.00"
+kotlinx_serialization_json_version = "1.6.0"
 gson_version = "2.8.5"
-activity_compose_version = "1.5.1"
-core_version = "1.6.0"
-appcompat_version = "1.6.1"
-material_version = "1.8.0"
+activity_compose_version = "1.9.0"
+core_version = "1.13.1"
+appcompat_version = "1.7.0"
+material_version = "1.12.0"
 constraintlayout_version = "2.1.4"
-core_ktx_version = "1.6.0"
-lifecycle_runtime_ktx_version = "2.3.1"
+core_ktx_version = "1.13.1"
+lifecycle_runtime_ktx_version = "2.8.1"
 junit_version = "4.13.2"
-kotlinx_coroutines_test_version = "1.7.1"
+kotlinx_coroutines_test_version = "1.8.1"
+room_runtime_version = "2.6.1"
 test_ext_junit_version = "1.1.5"
 espresso_core_version = "3.5.1"
 test_runner_version = "1.4.0"
 test_rules_version = "1.4.0"
-kotlin = "1.8.21"
+kotlin = "1.9.0"
 kotlinx_coroutines_core_version = "1.8.1"
 mockk_version = "1.12.8"
+threetenbpVersion = "1.6.8"
+workRuntimeKtxVersion = "2.9.0"
+serialization_version = "1.6.0"
 
 
 [libraries]
+
+# SQL
+
+javascriptengine = { module = "androidx.javascriptengine:javascriptengine", version.ref = "javascriptengineVersion" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "room_runtime_version" }
+room-ktx = { module = "androidx.room:room-ktx", version.ref = "room_runtime_version" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "room_runtime_version" }
+
 
 # Billing
 billing = { module = "com.android.billingclient:billing", version.ref = "billing_version" }
@@ -37,6 +52,7 @@ browser = { module = "androidx.browser:browser", version.ref = "browser_version"
 # Compose
 compose_bom = { module = "androidx.compose:compose-bom", version.ref = "compose_version" }
 activity_compose = { module = "androidx.activity:activity-compose", version.ref = "activity_compose_version" }
+threetenbp = { module = "org.threeten:threetenbp", version.ref = "threetenbpVersion" }
 ui = { module = "androidx.compose.ui:ui" }
 ui_graphics = { module = "androidx.compose.ui:ui-graphics" }
 ui_tooling_preview = { module = "androidx.compose.ui:ui-tooling-preview" }
@@ -49,9 +65,12 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout_version" }
 core_ktx = { module = "androidx.core:core-ktx", version.ref = "core_ktx_version" }
 lifecycle_runtime_ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle_runtime_ktx_version" }
+work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtxVersion" }
+lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleProcessVersion" }
 
 # Coroutines
 kotlinx_coroutines_core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx_coroutines_core_version" }
+kotlinx-coroutines-guava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-guava", version.ref = "kotlinxCoroutinesGuavaVersion" }
 
 # Serialization
 kotlinx_serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx_serialization_json_version" }
@@ -76,3 +95,4 @@ ui_test_manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradle_plugin_version" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization_version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ espresso_core_version = "3.5.1"
 test_runner_version = "1.4.0"
 test_rules_version = "1.4.0"
 kotlin = "1.8.21"
-kotlinx_coroutines_core_version = "1.7.1"
+kotlinx_coroutines_core_version = "1.8.1"
 mockk_version = "1.12.8"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri May 05 18:13:50 PDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -15,8 +15,7 @@ plugins {
     id("com.android.library")
     kotlin("android")
     kotlin("kapt")
-    kotlin("plugin.serialization") version "1.8.21"
-    // Maven publishing
+    alias(libs.plugins.serialization) // Maven publishing
     id("maven-publish")
     id("signing")
 }
@@ -24,7 +23,7 @@ plugins {
 version = "1.1.7"
 
 android {
-    compileSdk = 33
+    compileSdk = 34
     namespace = "com.superwall.sdk"
 
     defaultConfig {
@@ -69,17 +68,18 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = "1.5.0"
     }
 
     kotlinOptions {
         jvmTarget = "1.8"
     }
 
-    packagingOptions {
+    packaging {
         resources.excludes += "META-INF/LICENSE.md"
     }
 
@@ -173,15 +173,15 @@ tasks.register("generateBuildInfo") {
 }
 
 dependencies {
-    implementation("androidx.work:work-runtime-ktx:2.8.1")
-    implementation("androidx.lifecycle:lifecycle-process:2.5.0")
-    implementation("androidx.room:room-runtime:2.5.2")
-    implementation("androidx.room:room-ktx:2.5.2")
-    kapt("androidx.room:room-compiler:2.5.2")
-    implementation("androidx.javascriptengine:javascriptengine:1.0.0-beta01")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.6.0")
+    implementation(libs.work.runtime.ktx)
+    implementation(libs.lifecycle.process)
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    kapt(libs.room.compiler)
+    implementation(libs.javascriptengine)
+    implementation(libs.kotlinx.coroutines.guava)
 
-    implementation("org.threeten:threetenbp:1.6.8")
+    implementation(libs.threetenbp)
     // Billing
     implementation(libs.billing)
 

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
@@ -12,10 +12,11 @@ import com.superwall.sdk.models.triggers.TriggerRuleOutcome
 import com.superwall.sdk.models.triggers.UnmatchedRule
 import com.superwall.sdk.models.triggers.VariantOption
 import com.superwall.sdk.storage.StorageMock
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import java.util.*
+import java.util.Date
 
 class RuleAttributeFactoryBuilder : RuleAttributesFactory {
     override suspend fun makeRuleAttributes(
@@ -79,8 +80,7 @@ class ExpressionEvaluatorInstrumentedTest {
                             createdAt = Date(),
                         ),
                 )
-
-            assert(result == TriggerRuleOutcome.match(rule = rule))
+            assertEquals(TriggerRuleOutcome.match(rule = rule), result)
         }
 
     @Test

--- a/superwall/src/androidTest/java/com/superwall/sdk/storage/ConfigureSDKTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/storage/ConfigureSDKTest.kt
@@ -1,0 +1,25 @@
+package com.superwall.sdk.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.superwall.sdk.Superwall
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+const val CONSTANT_API_KEY = "pk_0ff90006c5c2078e1ce832bd2343ba2f806ca510a0a1696a"
+
+@RunWith(AndroidJUnit4::class)
+class ConfigureSDKTest {
+    @Test
+    fun configure_should_trigger_hasInitialised() =
+        runTest {
+            // Context of the app under test.
+            val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+            val superwall = Superwall.configure(appContext, CONSTANT_API_KEY)
+            val res = Superwall.hasInitialized.first()
+            assertEquals(true, res)
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.update
 import java.util.*
 
 class Superwall(
@@ -253,8 +254,8 @@ class Superwall(
 
             initialized = true
             // Ping everyone about the initialization
-            CoroutineScope(Dispatchers.Main).launch {
-                _hasInitialized.emit(true)
+            _hasInitialized.update {
+                true
             }
         }
     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/ShimmerView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/ShimmerView.kt
@@ -97,7 +97,7 @@ class ShimmerView(
         stopShimmer()
     }
 
-    override fun onDraw(canvas: Canvas?) {
+    override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         canvas ?: return
 

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -122,7 +122,7 @@ class ExternalNativePurchaseController(
         basePlanId: String?,
         offerId: String?,
     ): PurchaseResult {
-        //Clear previous purchase results to avoid emitting old results
+        // Clear previous purchase results to avoid emitting old results
         purchaseResults.value = null
 
         val fullId =


### PR DESCRIPTION
## Changes in this pull request


### Code

* Fixes `SW-2863` where some users would experience a crash on configuring the SDK, specifically the
`java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Class.isInterface()' on a null object reference` crash. The crash was happening due to a [known issue with coroutines and specific android versions](https://github.com/Kotlin/kotlinx.coroutines/issues/3820), fixed by updating to coroutines `1.8.1` version.

* Updates `hasInitialized` to emit in a thread-safe manner using `update` method.
* Adds test to cover `hasInitialized` listening
* Fixes `ExpressionEvaluator` not awaiting on initialisation, leading to race issues in testing
* Fixes test which did not previously compile due to lack of `SuperwallOptions` and `DeviceHelper`

### Libraries

* Updates the Kotlin dependency toolchain to **language version 1.9.0** and **coroutines version 1.8.1**
* Updates Gradle version to 8.7 & Android gradle plugin to 8.4.1  
* Updates the Android target SDK to 34 & Compose compiler to 1.5.0
* Updates the dependant libraries minimally to comply (i.e. compose, room, work manager) with other updates



- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

