### PR TITLE
Add error message to track webview load fail and product load fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.1.8
+
+### Enhancements
+
+- SW-2859: Adds error message to `paywallWebviewLoad_fail`.
+- SW-2866: Logs error when trying to purchase a product that has failed to load.
+
 ## 1.1.7
 
 ### Enhancements

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -596,7 +596,9 @@ sealed class InternalSuperwallEvent(
         sealed class State {
             class Start : State()
 
-            class Fail : State()
+            data class Fail(
+                val errorMessage: String,
+            ) : State()
 
             class Timeout : State()
 
@@ -619,6 +621,7 @@ sealed class InternalSuperwallEvent(
                     is PaywallWebviewLoad.State.Fail ->
                         SuperwallEvent.PaywallWebviewLoadFail(
                             paywallInfo,
+                            state.errorMessage,
                         )
 
                     is PaywallWebviewLoad.State.Complete ->

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -282,6 +282,7 @@ sealed class SuperwallEvent {
     // / When a paywall's website fails to load.
     data class PaywallWebviewLoadFail(
         val paywallInfo: PaywallInfo,
+        val errorMessage: String?,
     ) : SuperwallEvent() {
         override val rawName: String
             get() = "paywallWebviewLoad_fail"

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -90,7 +90,7 @@ class SWWebView(
                     error: WebResourceError?,
                 ) {
                     CoroutineScope(Dispatchers.Main).launch {
-                        trackPaywallError()
+                        trackPaywallError(error)
                     }
                 }
             }
@@ -135,14 +135,17 @@ class SWWebView(
         super.loadUrl(urlString)
     }
 
-    private suspend fun trackPaywallError() {
+    private suspend fun trackPaywallError(webResourceError: WebResourceError) {
         delegate?.paywall?.webviewLoadingInfo?.failAt = Date()
 
         val paywallInfo = delegate?.info ?: return
 
         val trackedEvent =
             InternalSuperwallEvent.PaywallWebviewLoad(
-                state = InternalSuperwallEvent.PaywallWebviewLoad.State.Fail(),
+                state =
+                    InternalSuperwallEvent.PaywallWebviewLoad.State.Fail(
+                        "Code: ${webResourceError.errorCode} - ${webResourceError.description}",
+                    ),
                 paywallInfo = paywallInfo,
             )
         Superwall.instance.track(trackedEvent)

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -122,7 +122,7 @@ class ExternalNativePurchaseController(
         basePlanId: String?,
         offerId: String?,
     ): PurchaseResult {
-        //Clear previous purchase results to avoid emitting old results
+        // Clear previous purchase results to avoid emitting old results
         purchaseResults.value = null
 
         val fullId =

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -57,7 +57,17 @@ class TransactionManager(
         productId: String,
         paywallViewController: PaywallViewController,
     ) {
-        val product = storeKitManager.productsByFullId[productId] ?: return
+        val product =
+            storeKitManager.productsByFullId[productId] ?: run {
+                Logger.debug(
+                    logLevel = LogLevel.error,
+                    scope = LogScope.paywallTransactions,
+                    message =
+                        "Trying to purchase ($productId) but the product has failed to load. Visit https://superwall.com/l/missing-products to diagnose.",
+                )
+                return
+            }
+
         val rawStoreProduct = product.rawStoreProduct
         println("!!! Purchasing product ${rawStoreProduct.hasFreeTrial}")
         val productDetails = rawStoreProduct.underlyingProductDetails


### PR DESCRIPTION
## Changes in this pull request

* Fixes SW-2859 - adds error message to `paywallWebviewLoad_fail` event
* Fixes SW-2866 - Adds logs to purchase if no product available to load.


- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

