### PR TITLE
Prevent geo api from being called when app in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - SW-2859: Adds error message to `paywallWebviewLoad_fail`.
 - SW-2866: Logs error when trying to purchase a product that has failed to load.
+- SW-2867: Prevents Geo api from being called when app is in the background
 
 ## 1.1.7
 


### PR DESCRIPTION
## Changes in this pull request

* Fixes SW-2867 - awaits until app in foreground when calling Geo API

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

