### PR TITLE
Add reset event to track when instance is reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - SW-2859: Adds error message to `paywallWebviewLoad_fail`.
 - SW-2866: Logs error when trying to purchase a product that has failed to load.
+- SW-2869: Add `Reset` event to track when `Superwall.instance.reset` is called.
 
 ## 1.1.7
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -47,6 +47,7 @@ class Superwall(
     private val completion: (() -> Unit)?,
 ) : PaywallViewControllerEventDelegate {
     private var _options: SuperwallOptions? = options
+    private val ioScope = CoroutineScope(Dispatchers.IO)
 
     // Add a private variable for the purchase task
     private var purchaseTask: Job? = null
@@ -287,7 +288,7 @@ class Superwall(
 
         addListeners()
 
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             dependencyContainer.storage.configure(apiKey = apiKey)
             dependencyContainer.storage.recordAppInstall {
                 track(event = it)
@@ -304,7 +305,7 @@ class Superwall(
 
     // / Listens to config and the subscription status
     private fun addListeners() {
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             subscriptionStatus // Removes duplicates by default
                 .drop(1) // Drops the first item
                 .collect { newValue ->
@@ -326,7 +327,7 @@ class Superwall(
      * @param isHidden Toggles the paywall loading spinner on and off.
      */
     fun togglePaywallSpinner(isHidden: Boolean) {
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             val paywallViewController = dependencyContainer.paywallManager.presentedViewController ?: return@launch
             paywallViewController.togglePaywallSpinner(isHidden)
         }
@@ -372,6 +373,9 @@ class Superwall(
         dependencyContainer.paywallManager.resetCache()
         presentationItems.reset()
         dependencyContainer.configManager.reset()
+        ioScope.launch {
+            track(InternalSuperwallEvent.Reset)
+        }
     }
 
     //region Deep Links
@@ -388,7 +392,7 @@ class Superwall(
      * @return A `Boolean` that is `true` if the deep link was handled.
      */
     fun handleDeepLink(uri: Uri): Boolean {
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             track(InternalSuperwallEvent.DeepLink(uri = uri))
         }
         return dependencyContainer.debugManager.handle(deepLinkUrl = uri)
@@ -408,7 +412,7 @@ class Superwall(
      * Note: This will not reload any paywalls you've already preloaded via [preloadPaywalls].
      */
     fun preloadAllPaywalls() {
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             dependencyContainer.configManager.preloadAllPaywalls()
         }
     }
@@ -424,7 +428,7 @@ class Superwall(
      * @param eventNames A set of names of events whose paywalls you want to preload.
      */
     fun preloadPaywalls(eventNames: Set<String>) {
-        CoroutineScope(Dispatchers.IO).launch {
+        ioScope.launch {
             dependencyContainer.configManager.preloadPaywallsByNames(
                 eventNames = eventNames,
             )

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -708,6 +708,12 @@ sealed class InternalSuperwallEvent(
         }
     }
 
+    object Reset : InternalSuperwallEvent(SuperwallEvent.Reset) {
+        override val customParameters: Map<String, Any> = emptyMap()
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
+    }
+
     data class Restore(
         val state: State,
         val paywallInfo: PaywallInfo,

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -358,6 +358,12 @@ sealed class SuperwallEvent {
             get() = "survey_close"
     }
 
+    // When Superwall.instance.reset is called
+    object Reset : SuperwallEvent() {
+        override val rawName: String
+            get() = "reset"
+    }
+
     open val rawName: String
         get() = this.toString()
 


### PR DESCRIPTION
## Changes in this pull request

* Fixes SW-2869 - adds `Reset` event to track when `Superwall.instance.reset` is invoked
* Unifies IO scope usage in `Superwall` class to use the same scope

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

