### PR TITLE
Remove globalscope usages and replace Default scope with IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 - SW-2866: Logs error when trying to purchase a product that has failed to load.
 - SW-2869: Add `Reset` event to track when `Superwall.instance.reset` is called.
 - SW-2867: Prevents Geo api from being called when app is in the background
+- SW-2431: Improves coroutine scope usages & threading limits
 - Toolchain and dependency updates
 
 ### Fixes

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
@@ -10,24 +10,26 @@ import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationReques
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-fun Superwall.logErrors(
+suspend fun Superwall.logErrors(
     request: PresentationRequest,
     error: Throwable,
 ) {
     if (error is PaywallPresentationRequestStatusReason) {
-        GlobalScope.launch(Dispatchers.IO) {
-            val trackedEvent =
-                InternalSuperwallEvent.PresentationRequest(
-                    eventData = request.presentationInfo.eventData,
-                    type = request.flags.type,
-                    status = PaywallPresentationRequestStatus.NoPresentation,
-                    statusReason = error,
-                    factory = dependencyContainer,
-                )
-            track(trackedEvent)
+        withContext(Dispatchers.IO) {
+            launch {
+                val trackedEvent =
+                    InternalSuperwallEvent.PresentationRequest(
+                        eventData = request.presentationInfo.eventData,
+                        type = request.flags.type,
+                        status = PaywallPresentationRequestStatus.NoPresentation,
+                        statusReason = error,
+                        factory = dependencyContainer,
+                    )
+                track(trackedEvent)
+            }
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -31,7 +31,6 @@ import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -44,6 +43,8 @@ class TransactionManager(
     private val factory: Factory,
     private val context: Context,
 ) {
+    val scope = CoroutineScope(Dispatchers.IO)
+
     interface Factory :
         OptionsFactory,
         TriggerFactory,
@@ -189,7 +190,7 @@ class TransactionManager(
         )
 
         // Launch a coroutine to handle async tasks
-        CoroutineScope(Dispatchers.Default).launch {
+        scope.launch {
             val paywallInfo = paywallViewController.info
             val trackedEvent =
                 InternalSuperwallEvent.Transaction(
@@ -214,7 +215,7 @@ class TransactionManager(
         product: StoreProduct,
         paywallViewController: PaywallViewController,
     ) {
-        GlobalScope.launch(Dispatchers.Default) {
+        scope.launch {
             Logger.debug(
                 LogLevel.debug,
                 LogScope.paywallTransactions,
@@ -246,7 +247,7 @@ class TransactionManager(
         product: StoreProduct,
         paywallViewController: PaywallViewController,
     ) {
-        GlobalScope.launch(Dispatchers.Default) {
+        scope.launch {
             Logger.debug(
                 LogLevel.debug,
                 LogScope.paywallTransactions,
@@ -285,7 +286,7 @@ class TransactionManager(
         product: StoreProduct,
         paywallViewController: PaywallViewController,
     ) {
-        GlobalScope.launch(Dispatchers.Default) {
+        scope.launch {
             Logger.debug(
                 LogLevel.debug,
                 LogScope.paywallTransactions,
@@ -314,7 +315,7 @@ class TransactionManager(
     }
 
     private suspend fun handlePendingTransaction(paywallViewController: PaywallViewController) {
-        GlobalScope.launch(Dispatchers.Default) {
+        scope.launch {
             Logger.debug(
                 LogLevel.debug,
                 LogScope.paywallTransactions,
@@ -415,7 +416,7 @@ class TransactionManager(
         product: StoreProduct,
         paywallViewController: PaywallViewController,
     ) {
-        GlobalScope.launch(Dispatchers.Default) {
+        scope.launch {
             Logger.debug(
                 LogLevel.debug,
                 LogScope.paywallTransactions,


### PR DESCRIPTION
## Changes in this pull request

* Fixes SW-2341 - Migrates `GlobalScope` usages to IO
* Replaces `Default` dispatcher with `IO` scope dispatcher - `Default` limits threads by the device core count, so this way our coroutines get some more headroom to execute 
 
*Note: Not supper happy with the solution as I'd prefer to inject it from the outside as a dependency, tho that unravels a large thread of refactors so decided to keep it for later

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

