### PR TITLE
Replace iOS lifecycle naming with Android lifecycle equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,29 @@ path is provided. The notable ones in the public API are as follows:
 - Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.
 - Deprecated `DebugViewControllerActivity` in favor of `DebugViewActivity`
 - Deprecated `PaywallViewController` in favor of `PaywallView`
-- Deprecated `PaywallViewControllerDelegate` in favor of `PaywallViewDelegate`
-- Deprecated `PaywallViewControllerEventDelegate` in favor of `PaywallViewEventDelegate`
-- Deprecated `Superwall.paywallViewController` in favor of `Superwall.paywallView`
-- Deprecated `Superwall.eventDidOccur` argument `paywallViewController` in favor of `paywallView`
-- Deprecated `Superwall.dismiss` in favor of `Superwall.presentPaywallView
-- Deprecated `Superwall.presentPaywallViewController` in favor of `Superwall.presentPaywallView`
+  - Deprecated belonging methods:
+    - `viewWillAppear` in favor of `beforeViewCreated`
+    - `viewDidAppear` in favor of `onViewCreated`
+    - `viewWillDisappear` in favor of `beforeOnDestroy`
+    - `viewDidDisappear` in favor of `destroyed`
+    - `presentAlert` in favor of `showAlert`
+- Deprecated `PaywallViewControllerDelegate` in favor of `PaywallViewCallback`
+  - Deprecated belonging methods:
+    -  `didFinish` in favor of `onFinished`
+- Deprecated `PaywallViewControllerEventDelegate` in favor of `PaywallViewEventCallback`
+  - Users might also note deprecation of `PaywallWebEvent.OpenedUrlInSafari` in favor of `PaywallWebEvent.OpenedUrlInChrome`
+    -  `didFinish` in favor of `onFinished`
+
+- In `Superwall`, the following methods were deprecated:
+  - `Superwall.paywallViewController` in favor of `Superwall.paywallView`
+  - `Superwall.eventDidOccur` argument `paywallViewController` in favor of `paywallView`
+  - `Superwall.dismiss` in favor of `Superwall.presentPaywallView
+  - `Superwall.presentPaywallViewController` in favor of `Superwall.presentPaywallView`
 - Deprecated `Paywallmanager.getPaywallViewController` in favor of `PaywallManager.getPaywallView`
 - Deprecated `DebugManager.viewController` in favor of `DebugManager.view`
 - Deprecated `DebugViewController` in favor of `DebugView`
 - Deprecated `LogScope.debugViewController` in favor of `LogScope.debugView`
 - Deprecated `PaywallPresentationRequestStatus.NoPaywallViewController` in favor of `NoPaywallView`
-- 
 
 ### Fixes
 

--- a/app/src/main/java/com/superwall/superapp/ComposeActivity.kt
+++ b/app/src/main/java/com/superwall/superapp/ComposeActivity.kt
@@ -29,12 +29,12 @@ import com.superwall.sdk.composable.PaywallComposable
 import com.superwall.sdk.paywall.presentation.internal.request.PaywallOverrides
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.vc.PaywallView
-import com.superwall.sdk.paywall.vc.delegate.PaywallViewDelegate
+import com.superwall.sdk.paywall.vc.delegate.PaywallViewCallback
 import com.superwall.superapp.ui.theme.MyApplicationTheme
 
 class ComposeActivity :
     ComponentActivity(),
-    PaywallViewDelegate {
+    PaywallViewCallback {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -42,7 +42,7 @@ class ComposeActivity :
         }
     }
 
-    override fun didFinish(
+    override fun onFinished(
         paywall: PaywallView,
         result: PaywallResult,
         shouldDismiss: Boolean,
@@ -54,7 +54,7 @@ class ComposeActivity :
 @Preview(showBackground = true)
 @Composable
 fun ComposeActivityContent(
-    @PreviewParameter(PreviewPaywallDelegateProvider::class) delegate: PaywallViewDelegate,
+    @PreviewParameter(PreviewPaywallDelegateProvider::class) delegate: PaywallViewCallback,
 ) {
     val selectedTabIndex = remember { mutableStateOf(0) }
     val examplePaywallOverrides = PaywallOverrides()
@@ -101,7 +101,7 @@ fun ComposeActivityContent(
 @Composable
 fun TabContent0(
     paywallOverrides: PaywallOverrides?,
-    delegate: PaywallViewDelegate,
+    delegate: PaywallViewCallback,
 ) {
     PaywallComposable(
         event = "no_products",
@@ -114,7 +114,7 @@ fun TabContent0(
 @Composable
 fun TabContent1(
     paywallOverrides: PaywallOverrides?,
-    delegate: PaywallViewDelegate,
+    delegate: PaywallViewCallback,
 ) {
     PaywallComposable(
         event = "no-existing-event",
@@ -167,12 +167,12 @@ fun EventButton() {
 }
 
 // Mock Provider for Preview
-class PreviewPaywallDelegateProvider : PreviewParameterProvider<PaywallViewDelegate> {
-    override val values: Sequence<PaywallViewDelegate> =
+class PreviewPaywallDelegateProvider : PreviewParameterProvider<PaywallViewCallback> {
+    override val values: Sequence<PaywallViewCallback> =
         sequenceOf(
-            object : PaywallViewDelegate {
-                // Mock implementation of PaywallViewControllerDelegate
-                override fun didFinish(
+            object : PaywallViewCallback {
+                // Mock implementation of PaywallViewDelegate
+                override fun onFinished(
                     paywall: PaywallView,
                     result: PaywallResult,
                     shouldDismiss: Boolean,

--- a/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
@@ -676,7 +676,7 @@ class UITestHandler {
         suspend fun test35() {
             // Create a mock paywall view controller
             val delegate = MockPaywallViewDelegate()
-            delegate.paywallViewDidFinish { paywallViewController, paywallResult, shouldDismiss ->
+            delegate.paywallViewFinished { paywallViewController, paywallResult, shouldDismiss ->
                 println("!!! TEST 35 !!! Result: $paywallResult, shouldDismiss: $shouldDismiss, paywallVc: $paywallViewController")
             }
 
@@ -697,7 +697,7 @@ class UITestHandler {
         suspend fun test36() {
             // Create a mock paywall view controller
             val delegate = MockPaywallViewDelegate()
-            delegate.paywallViewDidFinish { paywallViewController, paywallResult, shouldDismiss ->
+            delegate.paywallViewFinished { paywallViewController, paywallResult, shouldDismiss ->
                 println("!!! TEST 36 !!! Result: $paywallResult, shouldDismiss: $shouldDismiss, paywallVc: $paywallViewController")
             }
 
@@ -719,7 +719,7 @@ class UITestHandler {
         suspend fun test37() {
             // Create a mock paywall view controller
             val delegate = MockPaywallViewDelegate()
-            delegate.paywallViewDidFinish { paywallViewController, paywallResult, shouldDismiss ->
+            delegate.paywallViewFinished { paywallViewController, paywallResult, shouldDismiss ->
                 println("!!! TEST 37 !!! Result: $paywallResult, shouldDismiss: $shouldDismiss, paywallVc: $paywallViewController")
             }
 
@@ -1078,7 +1078,7 @@ class UITestHandler {
         suspend fun test63() {
             // Create a mock paywall view controller
             val delegate = MockPaywallViewDelegate()
-            delegate.paywallViewDidFinish { paywallViewController, paywallResult, shouldDismiss ->
+            delegate.paywallViewFinished { paywallViewController, paywallResult, shouldDismiss ->
                 println("!!! TEST 37 !!! Result: $paywallResult, shouldDismiss: $shouldDismiss, paywallVc: $paywallViewController")
             }
 
@@ -1288,7 +1288,7 @@ class UITestHandler {
 
             // Create a mock paywall view controller
             val paywallDelegate = MockPaywallViewDelegate()
-            paywallDelegate.paywallViewDidFinish { paywallViewController, paywallResult, shouldDismiss ->
+            paywallDelegate.paywallViewFinished { paywallViewController, paywallResult, shouldDismiss ->
                 println("!!! TEST 70 !!! Result: $paywallResult, shouldDismiss: $shouldDismiss, paywallVc: $paywallViewController")
                 if (shouldDismiss) {
                     CoroutineScope(Dispatchers.IO).launch {

--- a/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
@@ -4,31 +4,35 @@ import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.vc.PaywallView
-import com.superwall.sdk.paywall.vc.delegate.PaywallViewDelegate
+import com.superwall.sdk.paywall.vc.delegate.PaywallViewCallback
 
 @Deprecated("Will be removed in the upcoming versions, use MockPaywallViewDelegate instead")
 typealias MockPaywallViewControllerDelegate = MockPaywallViewDelegate
-class MockPaywallViewDelegate : PaywallViewDelegate {
-    private var paywallViewDidFinish: ((PaywallView, PaywallResult, Boolean) -> Unit)? = null
 
-    override fun didFinish(
+class MockPaywallViewDelegate : PaywallViewCallback {
+    private var paywallViewFinished: ((PaywallView, PaywallResult, Boolean) -> Unit)? = null
+
+    override fun didFinish(paywall: PaywallView, result: PaywallResult, shouldDismiss: Boolean) =
+        onFinished(paywall, result, shouldDismiss)
+
+    override fun onFinished(
         paywall: PaywallView,
         result: PaywallResult,
         shouldDismiss: Boolean,
     ) {
-        paywallViewDidFinish?.invoke(paywall, result, shouldDismiss)
+        paywallViewFinished?.invoke(paywall, result, shouldDismiss)
         if (shouldDismiss) {
             paywall.encapsulatingActivity?.finish()
         }
     }
 
-    @Deprecated("Will be removed in the upcoming versions, use paywallViewDidFinish instead")
+    @Deprecated("Will be removed in the upcoming versions, use paywallViewFinished instead")
     fun paywallViewControllerDidFinish(handler: (PaywallView, PaywallResult, Boolean) -> Unit) {
-        paywallViewDidFinish(handler)
+        paywallViewFinished(handler)
     }
 
-    fun paywallViewDidFinish(handler: (PaywallView, PaywallResult, Boolean) -> Unit) {
-        paywallViewDidFinish = handler
+    fun paywallViewFinished(handler: (PaywallView, PaywallResult, Boolean) -> Unit) {
+        paywallViewFinished = handler
     }
 }
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -25,7 +25,7 @@ import com.superwall.sdk.paywall.presentation.internal.dismiss
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.vc.PaywallView
 import com.superwall.sdk.paywall.vc.SuperwallPaywallActivity
-import com.superwall.sdk.paywall.vc.delegate.PaywallViewEventDelegate
+import com.superwall.sdk.paywall.vc.delegate.PaywallViewEventCallback
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.*
 import com.superwall.sdk.storage.ActiveSubscriptionStatus
@@ -46,7 +46,7 @@ class Superwall(
     options: SuperwallOptions?,
     private var activityProvider: ActivityProvider?,
     private val completion: (() -> Unit)?,
-) : PaywallViewEventDelegate {
+) : PaywallViewEventCallback {
     private var _options: SuperwallOptions? = options
     private val ioScope = CoroutineScope(Dispatchers.IO)
     internal var context: Context = context.applicationContext
@@ -501,7 +501,7 @@ class Superwall(
                 is OpenedURL -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenURL(url = paywallEvent.url)
                 }
-                is OpenedUrlInSafari -> {
+                is OpenedUrlInChrome -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenURL(url = paywallEvent.url)
                 }
                 is OpenedDeepLink -> {

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -3,7 +3,7 @@ package com.superwall.sdk.analytics.internal
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.internal.trackable.Trackable
 import com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent
-import com.superwall.sdk.analytics.superwall.SuperwallEventObjc
+import com.superwall.sdk.analytics.superwall.SuperwallEvents
 import com.superwall.sdk.paywall.vc.PaywallView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -145,12 +145,12 @@ sealed class TrackingLogic {
 
         @Throws(Exception::class)
         fun checkNotSuperwallEvent(event: String) {
-            // Try to create a SuperwallEventObjc from the event string
-            val superwallEventObjc =
-                SuperwallEventObjc.values().find { superwallEvent ->
+            // Try to create a SuperwallEvents event from the event string
+            val superwallEvent =
+                SuperwallEvents.values().find { superwallEvent ->
                     superwallEvent.rawName == event
                 }
-            if (superwallEventObjc != null) {
+            if (superwallEvent != null) {
                 // Log error saying do not track an event with the same name as a SuperwallEvent
                 throw Exception("Do not track an event with the same name as a SuperwallEvent")
             }
@@ -161,7 +161,7 @@ sealed class TrackingLogic {
             triggers: Set<String>,
             paywallView: PaywallView?,
         ): ImplicitTriggerOutcome {
-            if (event is TrackableSuperwallEvent && event.superwallEvent.rawName == SuperwallEventObjc.DeepLink.rawName) {
+            if (event is TrackableSuperwallEvent && event.superwallEvent.rawName == SuperwallEvents.DeepLink.rawName) {
                 return ImplicitTriggerOutcome.DeepLinkTrigger
             }
 
@@ -172,9 +172,9 @@ sealed class TrackingLogic {
 
             val notAllowedReferringEventNames: Set<String> =
                 setOf(
-                    SuperwallEventObjc.TransactionAbandon.rawName,
-                    SuperwallEventObjc.TransactionFail.rawName,
-                    SuperwallEventObjc.PaywallDecline.rawName,
+                    SuperwallEvents.TransactionAbandon.rawName,
+                    SuperwallEvents.TransactionFail.rawName,
+                    SuperwallEvents.PaywallDecline.rawName,
                 )
 
             val referringEventName = paywallView?.info?.presentedByEventWithName
@@ -186,11 +186,11 @@ sealed class TrackingLogic {
             }
 
             if (event is TrackableSuperwallEvent) {
-                return when (event.superwallEvent.objcEvent) {
-                    SuperwallEventObjc.TransactionAbandon,
-                    SuperwallEventObjc.TransactionFail,
-                    SuperwallEventObjc.SurveyResponse,
-                    SuperwallEventObjc.PaywallDecline,
+                return when (event.superwallEvent.backingEvent) {
+                    SuperwallEvents.TransactionAbandon,
+                    SuperwallEvents.TransactionFail,
+                    SuperwallEvents.SurveyResponse,
+                    SuperwallEvents.PaywallDecline,
                     -> ImplicitTriggerOutcome.ClosePaywallThenTriggerPaywall
                     else -> ImplicitTriggerOutcome.TriggerPaywall
                 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -367,9 +367,9 @@ sealed class SuperwallEvent {
     open val rawName: String
         get() = this.toString()
 
-    open val objcEvent: SuperwallEventObjc
+    open val backingEvent: SuperwallEvents
         get() {
-            return SuperwallEventObjc.values().find { it.rawName == rawName }!!
+            return SuperwallEvents.values().find { it.rawName == rawName }!!
         }
 
     val canImplicitlyTriggerPaywall: Boolean

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -1,6 +1,9 @@
 package com.superwall.sdk.analytics.superwall
 
-enum class SuperwallEventObjc(
+
+@Deprecated("Will be removed in the upcoming versions, use SuperwallEvents instead")
+typealias SuperwallEventObjc = SuperwallEvents
+enum class SuperwallEvents(
     val rawName: String,
 ) {
     FirstSeen("first_seen"),

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -311,12 +311,12 @@ class DependencyContainer(
                     paywall = paywall,
                     factory = this@DependencyContainer,
                     cache = cache,
-                    delegate = delegate,
+                    callback = delegate,
                     deviceHelper = deviceHelper,
                     paywallManager = paywallManager,
                     storage = storage,
                     webView = webView,
-                    eventDelegate = Superwall.instance,
+                    eventCallback = Superwall.instance,
                 )
             webView.delegate = paywallView
             messageHandler.delegate = paywallView

--- a/superwall/src/main/java/com/superwall/sdk/deprecated/PaywallMessages.kt
+++ b/superwall/src/main/java/com/superwall/sdk/deprecated/PaywallMessages.kt
@@ -29,7 +29,7 @@ sealed class PaywallMessage {
         val url: URL,
     ) : PaywallMessage()
 
-    data class OpenUrlInSafari(
+    data class OpenUrlInBrowser(
         val url: URL,
     ) : PaywallMessage()
 
@@ -70,7 +70,7 @@ private fun parsePaywallMessage(json: JSONObject): PaywallMessage {
         "close" -> PaywallMessage.Close
         "restore" -> PaywallMessage.Restore
         "open_url" -> PaywallMessage.OpenUrl(URL(json.getString("url")))
-        "open_url_external" -> PaywallMessage.OpenUrlInSafari(URL(json.getString("url")))
+        "open_url_external" -> PaywallMessage.OpenUrlInBrowser(URL(json.getString("url")))
         "open_deep_link" -> PaywallMessage.OpenDeepLink(Uri.parse(json.getString("link")))
         "purchase" -> PaywallMessage.Purchase(json.getString("product"))
         "custom" -> PaywallMessage.Custom(json.getString("data"))

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
@@ -95,7 +95,7 @@ class PaywallManager(
             if (!request.isDebuggerLaunched) {
                 cache.getPaywallView(cacheKey)?.let { view ->
                     if (!isPreloading) {
-                        view.delegate = delegate
+                        view.callback = delegate
                         view.paywall.update(paywall)
                     }
                     return@withContext view

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/PublicGetPaywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/PublicGetPaywall.kt
@@ -7,7 +7,7 @@ import com.superwall.sdk.paywall.presentation.internal.PresentationRequestType
 import com.superwall.sdk.paywall.presentation.internal.request.PaywallOverrides
 import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
 import com.superwall.sdk.paywall.vc.PaywallView
-import com.superwall.sdk.paywall.vc.delegate.PaywallViewDelegate
+import com.superwall.sdk.paywall.vc.delegate.PaywallViewCallback
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewDelegateAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -17,7 +17,7 @@ suspend fun Superwall.getPaywall(
     event: String,
     params: Map<String, Any>? = null,
     paywallOverrides: PaywallOverrides? = null,
-    delegate: PaywallViewDelegate,
+    delegate: PaywallViewCallback,
 ): PaywallView =
     withContext(Dispatchers.Main) {
         val view =

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/GetPaywallComponents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/GetPaywallComponents.kt
@@ -44,14 +44,14 @@ suspend fun Superwall.getPaywallComponents(
 
     confirmHoldoutAssignment(request = request, rulesOutcome = rulesOutcome)
 
-    val paywallViewController = getPaywallView(request, rulesOutcome, debugInfo, publisher, dependencyContainer)
+    val paywallView = getPaywallView(request, rulesOutcome, debugInfo, publisher, dependencyContainer)
 
-    val presenter = getPresenterIfNecessary(paywallViewController, rulesOutcome, request, publisher)
+    val presenter = getPresenterIfNecessary(paywallView, rulesOutcome, request, publisher)
 
     confirmPaywallAssignment(rulesOutcome.confirmableAssignment, request, request.flags.isDebuggerLaunched)
 
     return PaywallComponents(
-        view = paywallViewController,
+        view = paywallView,
         presenter = presenter,
         rulesOutcome = rulesOutcome,
         debugInfo = debugInfo,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/delegate/PaywallViewCallback.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/delegate/PaywallViewCallback.kt
@@ -5,21 +5,30 @@ import com.superwall.sdk.paywall.vc.PaywallView
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent
 
 @Deprecated("Will be removed in the upcoming versions, use PaywallViewDelegate instead")
-typealias PaywallViewControllerDelegate = PaywallViewDelegate
+typealias PaywallViewControllerDelegate = PaywallViewCallback
 
 @Deprecated("Will be removed in the upcoming versions, use PaywallViewEventDelegate instead")
-typealias PaywallViewControllerEventDelegate = PaywallViewEventDelegate
+typealias PaywallViewControllerEventDelegate = PaywallViewEventCallback
 
-interface PaywallViewDelegate {
+interface PaywallViewCallback {
     // TODO: missing `shouldDismiss`
+
+    @Deprecated("Will be removed in the upcoming versions, use onFinish instead")
     fun didFinish(
         paywall: PaywallView,
         result: PaywallResult,
         shouldDismiss: Boolean,
+    ) = onFinished(paywall, result, shouldDismiss)
+
+    fun onFinished(
+        paywall: PaywallView,
+        result: PaywallResult,
+        shouldDismiss: Boolean,
     )
+
 }
 
-interface PaywallViewEventDelegate {
+fun interface PaywallViewEventCallback {
     suspend fun eventDidOccur(
         paywallEvent: PaywallWebEvent,
         paywallView: PaywallView,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/delegate/PaywallViewDelegateAdapter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/delegate/PaywallViewDelegateAdapter.kt
@@ -6,18 +6,26 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class PaywallViewDelegateAdapter(
-    val kotlinDelegate: PaywallViewDelegate?,
+    val kotlinDelegate: PaywallViewCallback?,
 ) {
     val hasJavaDelegate: Boolean
         get() = false
 
+    @Deprecated("Will be removed in the upcoming versions, use onFinished instead")
     suspend fun didFinish(
         paywall: PaywallView,
         result: PaywallResult,
         shouldDismiss: Boolean,
+    ) = onFinished(paywall, result, shouldDismiss)
+
+    suspend fun onFinished(
+        paywall: PaywallView,
+        result: PaywallResult,
+        shouldDismiss: Boolean,
     ) = withContext(Dispatchers.Main) {
-        kotlinDelegate?.didFinish(paywall, result, shouldDismiss)
+        kotlinDelegate?.onFinished(paywall, result, shouldDismiss)
     }
+
 }
 
 @Deprecated("Will be removed in the upcoming versions, use PaywallViewDelegateAdapter instead")

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
@@ -29,7 +29,7 @@ sealed class PaywallMessage {
         val url: URL,
     ) : PaywallMessage()
 
-    data class OpenUrlInSafari(
+    data class OpenUrlInBrowser(
         val url: URL,
     ) : PaywallMessage()
 
@@ -73,7 +73,7 @@ private fun parsePaywallMessage(json: JSONObject): PaywallMessage {
         "close" -> PaywallMessage.Close
         "restore" -> PaywallMessage.Restore
         "open_url" -> PaywallMessage.OpenUrl(URL(json.getString("url")))
-        "open_url_external" -> PaywallMessage.OpenUrlInSafari(URL(json.getString("url")))
+        "open_url_external" -> PaywallMessage.OpenUrlInBrowser(URL(json.getString("url")))
         "open_deep_link" -> PaywallMessage.OpenDeepLink(Uri.parse(json.getString("link")))
         "purchase" ->
             PaywallMessage.Purchase(

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -43,9 +43,15 @@ interface PaywallMessageHandlerDelegate {
 
     fun openDeepLink(url: String)
 
-    fun presentSafariInApp(url: String)
+    @Deprecated("Will be removed in the upcoming versions, use presentBrowserInApp instead")
+    fun presentSafariInApp(url: String) = presentBrowserInApp(url)
 
-    fun presentSafariExternal(url: String)
+    @Deprecated("Will be removed in the upcoming versions, use presentBrowserExternal instead")
+    fun presentSafariExternal(url: String) = presentBrowserExternal(url)
+
+    fun presentBrowserInApp(url: String)
+
+    fun presentBrowserExternal(url: String)
 }
 
 class PaywallMessageHandler(
@@ -98,7 +104,7 @@ class PaywallMessageHandler(
             }
 
             is PaywallMessage.OpenUrl -> openUrl(message.url)
-            is PaywallMessage.OpenUrlInSafari -> openUrlInSafari(message.url)
+            is PaywallMessage.OpenUrlInBrowser -> openUrlInBrowser(message.url)
             is PaywallMessage.OpenDeepLink -> openDeepLink(URL(message.url.toString()))
             is PaywallMessage.Restore -> restorePurchases()
             is PaywallMessage.Purchase -> purchaseProduct(withId = message.productId)
@@ -271,17 +277,20 @@ class PaywallMessageHandler(
         )
         hapticFeedback()
         delegate?.eventDidOccur(PaywallWebEvent.OpenedURL(url))
-        delegate?.presentSafariInApp(url.toString())
+        delegate?.presentBrowserInApp(url.toString())
     }
 
-    private fun openUrlInSafari(url: URL) {
+    @Deprecated("Will be removed in the upcoming versions, use openUrlInChrome instead")
+    private fun openUrlInSafari(url: URL) = openUrlInBrowser(url)
+
+    private fun openUrlInBrowser(url: URL) {
         detectHiddenPaywallEvent(
             "openUrlInSafari",
             mapOf("url" to url),
         )
         hapticFeedback()
-        delegate?.eventDidOccur(PaywallWebEvent.OpenedUrlInSafari(url))
-        delegate?.presentSafariExternal(url.toString())
+        delegate?.eventDidOccur(PaywallWebEvent.OpenedUrlInChrome(url))
+        delegate?.presentBrowserExternal(url.toString())
     }
 
     private fun openDeepLink(url: URL) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallWebEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallWebEvent.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.net.URL
 
+
 @Serializable
 sealed class PaywallWebEvent {
     object Closed : PaywallWebEvent()
@@ -26,7 +27,7 @@ sealed class PaywallWebEvent {
     ) : PaywallWebEvent()
 
     @SerialName("opened_url_in_safari")
-    data class OpenedUrlInSafari(
+    data class OpenedUrlInChrome(
         val url: URL,
     ) : PaywallWebEvent()
 

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -5,7 +5,7 @@ import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.SessionEventsManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
-import com.superwall.sdk.analytics.superwall.SuperwallEventObjc
+import com.superwall.sdk.analytics.superwall.SuperwallEvents
 import com.superwall.sdk.delegate.PurchaseResult
 import com.superwall.sdk.delegate.RestorationResult
 import com.superwall.sdk.delegate.SubscriptionStatus
@@ -102,7 +102,7 @@ class TransactionManager(
                     superwallOptions.paywalls.shouldShowPurchaseFailureAlert
                 val triggers = factory.makeTriggers()
                 val transactionFailExists =
-                    triggers.contains(SuperwallEventObjc.TransactionFail.rawName)
+                    triggers.contains(SuperwallEvents.TransactionFail.rawName)
 
                 if (shouldShowPurchaseFailureAlert && !transactionFailExists) {
                     trackFailure(
@@ -336,7 +336,7 @@ class TransactionManager(
             )
         Superwall.instance.track(trackedEvent)
 
-        paywallView.presentAlert(
+        paywallView.showAlert(
             "Waiting for Approval",
             "Thank you! This purchase is pending approval from your parent. Please try again once it is approved.",
         )
@@ -403,7 +403,7 @@ class TransactionManager(
                 ),
             )
 
-            paywallView.presentAlert(
+            paywallView.showAlert(
                 title = Superwall.instance.options.paywalls.restoreFailed.title,
                 message = Superwall.instance.options.paywalls.restoreFailed.message,
                 closeActionTitle = Superwall.instance.options.paywalls.restoreFailed.closeButtonTitle,
@@ -445,7 +445,7 @@ class TransactionManager(
             )
         Superwall.instance.track(trackedEvent)
 
-        paywallView.presentAlert(
+        paywallView.showAlert(
             "An error occurred",
             error.message ?: "Unknown error",
         )

--- a/superwall/src/test/java/com/superwall/sdk/analytics/superwall/SuperwallEventTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/analytics/superwall/SuperwallEventTest.kt
@@ -6,6 +6,6 @@ class SuperwallEventTest {
     @Test
     fun test_app_install() {
         val event = SuperwallEvent.AppInstall()
-        assert(event.objcEvent == SuperwallEventObjc.AppInstall)
+        assert(event.backingEvent == SuperwallEvents.AppInstall)
     }
 }


### PR DESCRIPTION
## Changes in this pull request

* Replaces iOS Lifecycle method naming to its Android counterparts
* Old methods and classes are marked as `@Deprecated` and typealiased where possible to minimise impact on relying code
* Updates Safari references to be browser references
* Updates `Delegates` to be `Callbacks`


## TODO
- [x] Notify of breaking changes in the changelog 
- [x] Update [documentation where necessary](https://github.com/superwall/paywall-next/pull/1427)
 
- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [x] I have updated the SDK documentation as well as the online docs.

