### PR TITLE
Fixes SW-2878 memory leaks, adds `LeakCanary` and deprecates ambiguous context in `configure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.1.9
 
-### Enhancements
-
-- Adds [https://github.com/square/leakcanary](LeakCanary) to the testing application to help discover memory leaks.
-
 ### Deprecations
 
 - Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 1.1.9
+
+### Enhancements
+
+- Adds [https://github.com/square/leakcanary](LeakCanary) to the testing application to help discover memory leaks.
+
+### Deprecations
+
+- Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.
+
+### Fixes
+
+- Fixes SW-2878 and it's related leaks. The `PaywallViewController` was not being properly detached when activity was stopped, causing memory leaks.
+
+
 ## 1.1.8
 
 ### Enhancements

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     androidTestImplementation(libs.test.rules)
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.ui.test.junit4)
+    debugImplementation(libs.leakcanary.android)
 
     // Debug
     debugImplementation(libs.ui.tooling)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ browser_version = "1.5.0"
 gradle_plugin_version = "8.4.1"
 javascriptengineVersion = "1.0.0-beta01"
 kotlinxCoroutinesGuavaVersion = "1.8.1"
+leakcanaryAndroidVersion = "2.14"
 lifecycleProcessVersion = "2.8.1"
 mockk = "1.13.8"
 revenue_cat_version = "7.7.1"
@@ -37,6 +38,7 @@ serialization_version = "1.6.0"
 # SQL
 
 javascriptengine = { module = "androidx.javascriptengine:javascriptengine", version.ref = "javascriptengineVersion" }
+leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroidVersion" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room_runtime_version" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room_runtime_version" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room_runtime_version" }

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk
 
+import android.app.Application
 import android.content.Context
 import android.net.Uri
 import androidx.work.WorkManager
@@ -40,7 +41,7 @@ import kotlinx.coroutines.flow.update
 import java.util.*
 
 class Superwall(
-    internal var context: Context,
+    context: Context,
     private var apiKey: String,
     private var purchaseController: PurchaseController?,
     options: SuperwallOptions?,
@@ -49,6 +50,7 @@ class Superwall(
 ) : PaywallViewControllerEventDelegate {
     private var _options: SuperwallOptions? = options
     private val ioScope = CoroutineScope(Dispatchers.IO)
+    internal var context: Context = context.applicationContext
 
     // Add a private variable for the purchase task
     private var purchaseTask: Job? = null
@@ -217,7 +219,7 @@ class Superwall(
          * @return The configured [Superwall] instance.
          */
         fun configure(
-            applicationContext: Context,
+            applicationContext: Application,
             apiKey: String,
             purchaseController: PurchaseController? = null,
             options: SuperwallOptions? = null,
@@ -259,6 +261,25 @@ class Superwall(
                 true
             }
         }
+
+        @Deprecated(
+            "This constructor is too ambiguous and will be removed in upcoming versions. Use Superwall.configure(Application, ...) instead.",
+        )
+        fun configure(
+            applicationContext: Context,
+            apiKey: String,
+            purchaseController: PurchaseController? = null,
+            options: SuperwallOptions? = null,
+            activityProvider: ActivityProvider? = null,
+            completion: (() -> Unit)? = null,
+        ) = configure(
+            applicationContext.applicationContext as Application,
+            apiKey,
+            purchaseController,
+            options,
+            activityProvider,
+            completion,
+        )
     }
 
     private lateinit var _dependencyContainer: DependencyContainer

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -587,7 +587,7 @@ class PaywallViewController(
         action: (() -> Unit)? = null,
         onClose: (() -> Unit)? = null,
     ) {
-        val activity = encapsulatingActivity.let { it } ?: return
+        val activity = encapsulatingActivity ?: return
 
         val alertController =
             AlertControllerFactory.make(
@@ -957,7 +957,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-
+        (contentView?.parent as? ViewGroup)?.removeView(contentView)
         // Clear reference to activity in the view
         (contentView as? ActivityEncapsulatable)?.encapsulatingActivity = null
 


### PR DESCRIPTION
## Changes in this pull request

### Code

- Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety and . The rest of the method signature remains the same.

- Fixes SW-2878 and it's related leaks. The `PaywallViewController` was not being properly detached when activity was stopped, causing memory leaks.

### Libraries

- Adds [https://github.com/square/leakcanary](LeakCanary) to the testing application to help discover memory leaks.

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

