### PR TITLE
Fixes SW-2872 by awaiting for geo IP data, parallelizes config & geo calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.1.9
+
+### Fixes
+
+- SW-2872: Fixes issue where `deviceAttributes` event and fetching would not await for IP geo to complete.
+
+### Enhancements
+
+- Parallelized the fetching of configuration and IP geo info.
+
 ## 1.1.8
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - SW-2872: Fixes issue where `deviceAttributes` event and fetching would not await for IP geo to complete.
 
-### Enhancements
-
-- Parallelized the fetching of configuration and IP geo info.
-
 ## 1.1.8
 
 ### Enhancements

--- a/superwall/src/main/java/com/superwall/sdk/analytics/session/AppSessionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/session/AppSessionManager.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
-import java.util.*
+import java.util.Date
 
 interface AppManagerDelegate {
     suspend fun didUpdateAppSession(appSession: AppSession)
@@ -110,7 +110,13 @@ class AppSessionManager(
                 val userAttributes = delegate.makeUserAttributesEvent()
 
                 Superwall.instance.track(InternalSuperwallEvent.SessionStart())
-                Superwall.instance.track(InternalSuperwallEvent.DeviceAttributes(deviceAttributes))
+                if (didTrackAppLaunch) {
+                    Superwall.instance.track(
+                        InternalSuperwallEvent.DeviceAttributes(
+                            deviceAttributes,
+                        ),
+                    )
+                }
                 Superwall.instance.track(userAttributes)
             }
         } else {


### PR DESCRIPTION
## Changes in this pull request

- SW-2872: Fixes issue where `deviceAttributes` event and fetching would not await for IP geo to complete.
- Parallelized the fetching of configuration, IP geo info and building the device info.
- Adds `didTrackAppLaunch` to device attribute tracking in `AppSessionManager` like on iOS
 
## Checks
- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the CHANGELOG.md for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.

