### PR TITLE
Add idiomatic DSL for prettier configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.2.0
 
+### Enhancements
+- Adds DSL methods for configuring the SDK. You can now use a configuration block:
+  ```kotlin
+  fun Application.configureSuperwall(
+        apiKey: String,
+        configure: SuperwallBuilder.() -> Unit,
+  )
+  ```
+
+This allows you to configure the SDK in a more idiomatic way:
+  ```kotlin
+     configureSuperwall(CONSTANT_API_KEY){
+        options {
+          logging {
+            level = LogLevel.debug
+          }
+          paywalls {
+            shouldPreload = false
+          }
+        }
+    }
+  ```
+
 ### Deprecations
 
 This release includes multiple deprecations that will be removed in upcoming versions.
@@ -37,29 +60,6 @@ path is provided. The notable ones in the public API are as follows:
 - Deprecated `PaywallPresentationRequestStatus.NoPaywallViewController` in favor of `NoPaywallView`
 
 ## 1.1.9
-
-### Enhancements
-- Adds DSL methods for configuring the SDK. You can now use a configuration block:
-  ```kotlin
-  fun Application.configureSuperwall(
-        apiKey: String,
-        configure: SuperwallBuilder.() -> Unit,
-  )
-  ```
-  
- This allows you to configure the SDK in a more idiomatic way:
-  ```kotlin
-     configureSuperwall(CONSTANT_API_KEY){
-        options {
-          logging {
-            level = LogLevel.debug
-          }
-          paywalls {
-            shouldPreload = false
-          }
-        }
-    }
-  ```
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,29 @@ path is provided. The notable ones in the public API are as follows:
 
 ## 1.1.9
 
+### Enhancements
+- Adds DSL methods for configuring the SDK. You can now use a configuration block:
+  ```kotlin
+  fun Application.configureSuperwall(
+        apiKey: String,
+        configure: SuperwallBuilder.() -> Unit,
+  )
+  ```
+  
+ This allows you to configure the SDK in a more idiomatic way:
+  ```kotlin
+     configureSuperwall(CONSTANT_API_KEY){
+        options {
+          logging {
+            level = LogLevel.debug
+          }
+          paywalls {
+            shouldPreload = false
+          }
+        }
+    }
+  ```
+
 ### Deprecations
 
 - Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
-## 1.1.9
+## 1.2.0
 
 ### Deprecations
-
 
 This release includes multiple deprecations that will be removed in upcoming versions.
 Most are internal and will not affect the public API, those that will are marked as such and a simple migration
 path is provided. The notable ones in the public API are as follows:
 
-- Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.
 - Deprecated `DebugViewControllerActivity` in favor of `DebugViewActivity`
 - Deprecated `PaywallViewController` in favor of `PaywallView`
   - Deprecated belonging methods:
@@ -37,6 +35,12 @@ path is provided. The notable ones in the public API are as follows:
 - Deprecated `DebugViewController` in favor of `DebugView`
 - Deprecated `LogScope.debugViewController` in favor of `LogScope.debugView`
 - Deprecated `PaywallPresentationRequestStatus.NoPaywallViewController` in favor of `NoPaywallView`
+
+## 1.1.9
+
+### Deprecations
+
+- Deprecated configuration method `Superwall.configure(applicationContext: Context, ...)` in favor of `Superwall.configure(applicationContext: Application, ...)` to enforce type safety. The rest of the method signature remains the same.
 
 ### Fixes
 

--- a/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSL.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSL.kt
@@ -1,0 +1,47 @@
+package com.superwall.sdk.utilities
+
+import android.app.Application
+import com.superwall.sdk.Superwall
+import com.superwall.sdk.config.options.PaywallOptions
+import com.superwall.sdk.config.options.SuperwallOptions
+import com.superwall.sdk.delegate.subscription_controller.PurchaseController
+import com.superwall.sdk.misc.ActivityProvider
+
+class SuperwallBuilder {
+    var purchaseController: PurchaseController? = null
+    var options: SuperwallOptions? = null
+        private set
+    var activityProvider: ActivityProvider? = null
+    var completion: (() -> Unit)? = null
+
+    @SuperwallDSL
+    fun options(action: SuperwallOptions.() -> Unit) {
+        options = SuperwallOptions().apply(action)
+    }
+}
+
+@SuperwallDSL
+fun Application.configureSuperwall(
+    apiKey: String,
+    configure: SuperwallBuilder.() -> Unit,
+) {
+    val builder = SuperwallBuilder().apply(configure)
+    Superwall.configure(
+        this,
+        apiKey,
+        builder.purchaseController,
+        builder.options,
+        builder.activityProvider,
+        builder.completion,
+    )
+}
+
+@SuperwallDSL
+fun SuperwallOptions.paywalls(action: PaywallOptions.() -> Unit) {
+    paywalls = this.paywalls.apply(action)
+}
+
+@SuperwallDSL
+fun SuperwallOptions.logging(action: SuperwallOptions.Logging.() -> Unit) {
+    logging = this.logging.apply(action)
+}

--- a/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSL.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSL.kt
@@ -20,11 +20,28 @@ class SuperwallBuilder {
     }
 }
 
+/**
+ * Configures a shared instance of [Superwall] for use throughout your app.
+ *
+ * Call this as soon as your app finishes launching in `onCreate` in your `MainApplication`
+ * class.
+ * Check out [Configuring the SDK](https://docs.superwall.com/docs/configuring-the-sdk) for
+ * information about how to configure the SDK.
+ *
+ * @param apiKey Your Public API Key that you can get from the Superwall dashboard
+ * settings. If you don't have an account, you can
+ * [sign up for free](https://superwall.com/sign-up).
+ * @param configure A lambda that allows you to configure the SDK. Inside the configuration block,
+ * you can setup your [PurchaseController], [ActivityProvider], a completion
+ * closure and [SuperwallOptions] via [SuperwallBuilder.options] closure.
+ * @return The configured [Superwall] instance.
+ */
+
 @SuperwallDSL
 fun Application.configureSuperwall(
     apiKey: String,
     configure: SuperwallBuilder.() -> Unit,
-) {
+): Superwall {
     val builder = SuperwallBuilder().apply(configure)
     Superwall.configure(
         this,
@@ -34,13 +51,20 @@ fun Application.configureSuperwall(
         builder.activityProvider,
         builder.completion,
     )
+    return Superwall.instance
 }
 
+/**
+ * Enables you to define [PaywallOptions] via closure.
+ * */
 @SuperwallDSL
 fun SuperwallOptions.paywalls(action: PaywallOptions.() -> Unit) {
     paywalls = this.paywalls.apply(action)
 }
 
+/**
+ * Enables you to define [SuperwallOptions.Logging] via closure.
+ * */
 @SuperwallDSL
 fun SuperwallOptions.logging(action: SuperwallOptions.Logging.() -> Unit) {
     logging = this.logging.apply(action)

--- a/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSLUtils.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/SuperwallDSLUtils.kt
@@ -1,0 +1,4 @@
+package com.superwall.sdk.utilities
+
+@DslMarker
+annotation class SuperwallDSL


### PR DESCRIPTION
## Changes in this pull request

- Adds DSL methods for configuring the SDK, enabling users to use it in a more idiomatic way from Kotlin:

  ```kotlin
     configureSuperwall(CONSTANT_API_KEY){
        options {
           logging {
            level = LogLevel.debug
          }
          paywalls {
            shouldPreload = false
          }
        }
    }
  ```
  
### TODO
- [x] Add kdoc above the configuration methods
- [x] Update docs

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)
