### PR TITLE
Fix view storage losing state on configuration change

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -70,7 +70,7 @@ class Superwall(
 
     private val viewStorageViewModel =
         ViewModelProvider(
-            SuperwallStoreOwner,
+            SuperwallStoreOwner(),
             ViewModelFactory(),
         ).get(ViewStorageViewModel::class.java)
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -3,6 +3,7 @@ package com.superwall.sdk
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import androidx.lifecycle.ViewModelProvider
 import androidx.work.WorkManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
@@ -25,12 +26,23 @@ import com.superwall.sdk.paywall.presentation.internal.dismiss
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.vc.PaywallViewController
 import com.superwall.sdk.paywall.vc.SuperwallPaywallActivity
+import com.superwall.sdk.paywall.vc.SuperwallStoreOwner
+import com.superwall.sdk.paywall.vc.ViewModelFactory
+import com.superwall.sdk.paywall.vc.ViewStorageViewModel
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewControllerEventDelegate
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent
-import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.*
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.Closed
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.Custom
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.InitiatePurchase
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.InitiateRestore
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.OpenedDeepLink
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.OpenedURL
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent.OpenedUrlInSafari
 import com.superwall.sdk.storage.ActiveSubscriptionStatus
 import com.superwall.sdk.store.ExternalNativePurchaseController
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +50,8 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
-import java.util.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class Superwall(
     context: Context,
@@ -54,6 +67,14 @@ class Superwall(
 
     // Add a private variable for the purchase task
     private var purchaseTask: Job? = null
+
+    private val viewStorageViewModel =
+        ViewModelProvider(
+            SuperwallStoreOwner,
+            ViewModelFactory(),
+        ).get(ViewStorageViewModel::class.java)
+
+    internal fun viewStore(): ViewStorageViewModel = viewStorageViewModel
 
     internal val presentationItems: PresentationItems = PresentationItems()
 
@@ -165,7 +186,8 @@ class Superwall(
      */
     val latestPaywallInfo: PaywallInfo?
         get() {
-            val presentedPaywallInfo = dependencyContainer.paywallManager.presentedViewController?.info
+            val presentedPaywallInfo =
+                dependencyContainer.paywallManager.presentedViewController?.info
             return presentedPaywallInfo ?: presentationItems.paywallInfo
         }
 
@@ -305,7 +327,8 @@ class Superwall(
                 )
         }
 
-        val cachedSubsStatus = dependencyContainer.storage.get(ActiveSubscriptionStatus) ?: SubscriptionStatus.UNKNOWN
+        val cachedSubsStatus =
+            dependencyContainer.storage.get(ActiveSubscriptionStatus) ?: SubscriptionStatus.UNKNOWN
         setSubscriptionStatus(cachedSubsStatus)
 
         addListeners()
@@ -350,7 +373,8 @@ class Superwall(
      */
     fun togglePaywallSpinner(isHidden: Boolean) {
         ioScope.launch {
-            val paywallViewController = dependencyContainer.paywallManager.presentedViewController ?: return@launch
+            val paywallViewController =
+                dependencyContainer.paywallManager.presentedViewController ?: return@launch
             paywallViewController.togglePaywallSpinner(isHidden)
         }
     }
@@ -374,7 +398,9 @@ class Superwall(
      * Removes all of Superwall's pending local notifications.
      */
     fun cancelAllScheduledNotifications() {
-        WorkManager.getInstance(context).cancelAllWorkByTag(SuperwallPaywallActivity.NOTIFICATION_CHANNEL_ID)
+        WorkManager
+            .getInstance(context)
+            .cancelAllWorkByTag(SuperwallPaywallActivity.NOTIFICATION_CHANNEL_ID)
     }
 
     // MARK: - Reset
@@ -478,6 +504,7 @@ class Superwall(
                         closeReason = PaywallCloseReason.ManualClose,
                     )
                 }
+
                 is InitiatePurchase -> {
                     if (purchaseTask != null) {
                         // If a purchase is already in progress, do not start another
@@ -496,18 +523,23 @@ class Superwall(
                             }
                         }
                 }
+
                 is InitiateRestore -> {
                     dependencyContainer.transactionManager.tryToRestore(paywallViewController)
                 }
+
                 is OpenedURL -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenURL(url = paywallEvent.url)
                 }
+
                 is OpenedUrlInSafari -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenURL(url = paywallEvent.url)
                 }
+
                 is OpenedDeepLink -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenDeepLink(url = paywallEvent.url)
                 }
+
                 is Custom -> {
                     dependencyContainer.delegateAdapter.handleCustomPaywallAction(name = paywallEvent.string)
                 }

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
@@ -49,7 +49,6 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import com.superwall.sdk.paywall.request.PaywallRequestManager
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.vc.ActivityEncapsulatable
-import com.superwall.sdk.paywall.vc.ViewStorage
 import com.superwall.sdk.store.StoreKitManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -775,7 +774,7 @@ internal class DebugViewControllerActivity : AppCompatActivity() {
             view: View,
         ) {
             val key = UUID.randomUUID().toString()
-            ViewStorage.storeView(key, view)
+            Superwall.instance.viewStore().storeView(key, view)
 
             val intent =
                 Intent(context, DebugViewControllerActivity::class.java).apply {
@@ -804,7 +803,7 @@ internal class DebugViewControllerActivity : AppCompatActivity() {
             return
         }
         val view =
-            ViewStorage.retrieveView(key) ?: run {
+            Superwall.instance.viewStore().retrieveView(key) ?: run {
                 finish() // Close the activity if the view associated with the key is not found
                 return
             }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -1,41 +1,24 @@
 package com.superwall.sdk.paywall.vc
 
-import android.Manifest
-import android.R
 import android.app.Activity
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.graphics.Color
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
-import android.view.Window
-import android.view.WindowInsetsController
-import android.view.WindowManager
 import android.webkit.WebSettings
 import android.widget.FrameLayout
-import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.app.ActivityCompat
-import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEventObjc
 import com.superwall.sdk.config.models.OnDeviceCaching
 import com.superwall.sdk.config.options.PaywallOptions
-import com.superwall.sdk.dependencies.DeviceHelperFactory
 import com.superwall.sdk.dependencies.TriggerFactory
 import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
 import com.superwall.sdk.game.GameControllerDelegate
@@ -46,9 +29,7 @@ import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.AlertControllerFactory
 import com.superwall.sdk.misc.isDarkColor
-import com.superwall.sdk.misc.isLightColor
 import com.superwall.sdk.misc.readableOverlayColor
-import com.superwall.sdk.models.paywall.LocalNotification
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.paywall.PaywallPresentationStyle
 import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
@@ -75,7 +56,6 @@ import com.superwall.sdk.paywall.vc.web_view.SWWebViewDelegate
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallMessageHandlerDelegate
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent
 import com.superwall.sdk.storage.Storage
-import com.superwall.sdk.store.transactions.notifications.NotificationScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -83,8 +63,6 @@ import kotlinx.coroutines.launch
 import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 class PaywallViewController(
     context: Context,
@@ -269,6 +247,7 @@ class PaywallViewController(
         SuperwallPaywallActivity.startWithView(
             presenter,
             this,
+            cacheKey,
             presentationStyleOverride,
         )
         viewDidAppearCompletion = completion
@@ -795,285 +774,4 @@ class PaywallViewController(
 
 interface ActivityEncapsulatable {
     var encapsulatingActivity: Activity?
-}
-
-class SuperwallPaywallActivity : AppCompatActivity() {
-    companion object {
-        private const val REQUEST_CODE_NOTIFICATION_PERMISSION = 1001
-        const val NOTIFICATION_CHANNEL_ID = "com.superwall.android.notifications"
-        private const val NOTIFICATION_CHANNEL_NAME = "Trial Reminder Notifications"
-        private const val NOTIFICATION_CHANNEL_DESCRIPTION = "Notifications sent when a free trial is about to end."
-        private const val VIEW_KEY = "viewKey"
-        private const val PRESENTATION_STYLE_KEY = "presentationStyleKey"
-        private const val IS_LIGHT_BACKGROUND_KEY = "isLightBackgroundKey"
-
-        fun startWithView(
-            context: Context,
-            view: PaywallViewController,
-            presentationStyleOverride: PaywallPresentationStyle? = null,
-        ) {
-            val key = UUID.randomUUID().toString()
-            ViewStorage.storeView(key, view)
-
-            val intent =
-                Intent(context, SuperwallPaywallActivity::class.java).apply {
-                    putExtra(VIEW_KEY, key)
-                    putExtra(PRESENTATION_STYLE_KEY, presentationStyleOverride)
-                    putExtra(IS_LIGHT_BACKGROUND_KEY, view.paywall.backgroundColor.isLightColor())
-                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-                }
-
-            context.startActivity(intent)
-        }
-    }
-
-    private var contentView: View? = null
-    private var notificationPermissionCallback: NotificationPermissionCallback? = null
-
-    override fun setContentView(view: View) {
-        super.setContentView(view)
-        contentView = view
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
-
-        // Show content behind the status bar
-        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
-            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-        window.statusBarColor = Color.TRANSPARENT
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val isLightBackground = intent.getBooleanExtra(IS_LIGHT_BACKGROUND_KEY, false)
-            if (isLightBackground) {
-                window.insetsController?.let {
-                    it.setSystemBarsAppearance(
-                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
-                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
-                    )
-                }
-            }
-        }
-
-        requestWindowFeature(Window.FEATURE_NO_TITLE)
-
-        val key = intent.getStringExtra(VIEW_KEY)
-        if (key == null) {
-            finish() // Close the activity if there's no key
-            return
-        }
-
-        val view =
-            ViewStorage.retrieveView(key) as? PaywallViewController ?: run {
-                finish() // Close the activity if the view associated with the key is not found
-                return
-            }
-
-        (view.parent as? ViewGroup)?.removeView(view)
-        view.encapsulatingActivity = this
-
-        setContentView(view)
-
-        onBackPressedDispatcher.addCallback(
-            this,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    view.dismiss(
-                        result = PaywallResult.Declined(),
-                        closeReason = PaywallCloseReason.ManualClose,
-                    )
-                }
-            },
-        )
-
-        try {
-            supportActionBar?.hide()
-        } catch (e: Throwable) {
-        }
-
-        // TODO: handle animation and style from `presentationStyleOverride`
-        when (intent.getSerializableExtra(PRESENTATION_STYLE_KEY) as? PaywallPresentationStyle) {
-            PaywallPresentationStyle.PUSH -> {
-                overridePendingTransition(R.anim.slide_in_left, R.anim.slide_in_left)
-            }
-            PaywallPresentationStyle.DRAWER -> {
-            }
-            PaywallPresentationStyle.FULLSCREEN -> {
-            }
-            PaywallPresentationStyle.FULLSCREEN_NO_ANIMATION -> {
-            }
-            PaywallPresentationStyle.MODAL -> {
-            }
-            PaywallPresentationStyle.NONE -> {
-                // Do nothing
-            }
-            null -> {
-                // Do nothing
-            }
-        }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        val paywallVc = contentView as? PaywallViewController ?: return
-
-        if (paywallVc.isSafariVCPresented) {
-            paywallVc.isSafariVCPresented = false
-        }
-
-        paywallVc.viewWillAppear()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        val paywallVc = contentView as? PaywallViewController ?: return
-
-        paywallVc.viewDidAppear()
-    }
-
-    override fun onPause() {
-        super.onPause()
-
-        val paywallVc = contentView as? PaywallViewController ?: return
-
-        CoroutineScope(Dispatchers.Main).launch {
-            paywallVc.viewWillDisappear()
-        }
-    }
-
-    override fun onStop() {
-        super.onStop()
-
-        val paywallVc = contentView as? PaywallViewController ?: return
-
-        CoroutineScope(Dispatchers.Main).launch {
-            paywallVc.viewDidDisappear()
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        (contentView?.parent as? ViewGroup)?.removeView(contentView)
-        // Clear reference to activity in the view
-        (contentView as? ActivityEncapsulatable)?.encapsulatingActivity = null
-
-        // Clear the reference to the contentView
-        contentView = null
-    }
-
-    //region Notifications
-    interface NotificationPermissionCallback {
-        fun onPermissionResult(granted: Boolean)
-    }
-
-    suspend fun attemptToScheduleNotifications(
-        notifications: List<LocalNotification>,
-        factory: DeviceHelperFactory,
-        context: Context,
-    ) = suspendCoroutine { continuation ->
-        if (notifications.isEmpty()) {
-            continuation.resume(Unit) // Resume immediately as there's nothing to schedule
-            return@suspendCoroutine
-        }
-
-        createNotificationChannel()
-
-        notificationPermissionCallback =
-            object : NotificationPermissionCallback {
-                override fun onPermissionResult(granted: Boolean) {
-                    if (granted) {
-                        NotificationScheduler.scheduleNotifications(
-                            notifications = notifications,
-                            factory = factory,
-                            context = context,
-                        )
-                    }
-                    continuation.resume(Unit) // Resume coroutine after processing
-                }
-            }
-
-        checkAndRequestNotificationPermissions(this, notificationPermissionCallback!!)
-    }
-
-    private fun createNotificationChannel() {
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel =
-            NotificationChannel(
-                NOTIFICATION_CHANNEL_ID,
-                NOTIFICATION_CHANNEL_NAME,
-                importance,
-            ).apply {
-                description = NOTIFICATION_CHANNEL_DESCRIPTION
-            }
-        channel.setShowBadge(false)
-        // Register the channel with the system
-        val notificationManager: NotificationManager =
-            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(channel)
-    }
-
-    private fun checkAndRequestNotificationPermissions(
-        context: Context,
-        callback: NotificationPermissionCallback,
-    ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                if (!ActivityCompat.shouldShowRequestPermissionRationale(context as Activity, Manifest.permission.POST_NOTIFICATIONS)) {
-                    // First time asking or user previously denied without 'Don't ask again'
-                    ActivityCompat.requestPermissions(
-                        context,
-                        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                        REQUEST_CODE_NOTIFICATION_PERMISSION,
-                    )
-                } else {
-                    // Permission previously denied with 'Don't ask again'
-                    callback.onPermissionResult(false)
-                }
-            } else {
-                callback.onPermissionResult(true)
-            }
-        } else {
-            callback.onPermissionResult(areNotificationsEnabled(context))
-        }
-    }
-
-    private fun areNotificationsEnabled(context: Context): Boolean {
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channel = notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID)
-        if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
-            return false
-        }
-        return NotificationManagerCompat.from(context).areNotificationsEnabled()
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val isGranted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
-            // Invoke the callback here
-            notificationPermissionCallback?.onPermissionResult(isGranted)
-        }
-    }
-    //endregion
-}
-
-object ViewStorage {
-    private val views: MutableMap<String, View> = mutableMapOf()
-
-    fun storeView(
-        key: String,
-        view: View,
-    ) {
-        views[key] = view
-    }
-
-    fun retrieveView(key: String): View? = views.remove(key)
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -1,0 +1,309 @@
+package com.superwall.sdk.paywall.vc
+
+import android.Manifest
+import android.R
+import android.app.Activity
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowInsetsController
+import android.view.WindowManager
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.superwall.sdk.Superwall
+import com.superwall.sdk.dependencies.DeviceHelperFactory
+import com.superwall.sdk.misc.isLightColor
+import com.superwall.sdk.models.paywall.LocalNotification
+import com.superwall.sdk.models.paywall.PaywallPresentationStyle
+import com.superwall.sdk.paywall.presentation.PaywallCloseReason
+import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
+import com.superwall.sdk.store.transactions.notifications.NotificationScheduler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class SuperwallPaywallActivity : AppCompatActivity() {
+    companion object {
+        private const val REQUEST_CODE_NOTIFICATION_PERMISSION = 1001
+        const val NOTIFICATION_CHANNEL_ID = "com.superwall.android.notifications"
+        private const val NOTIFICATION_CHANNEL_NAME = "Trial Reminder Notifications"
+        private const val NOTIFICATION_CHANNEL_DESCRIPTION = "Notifications sent when a free trial is about to end."
+        private const val VIEW_KEY = "viewKey"
+        private const val PRESENTATION_STYLE_KEY = "presentationStyleKey"
+        private const val IS_LIGHT_BACKGROUND_KEY = "isLightBackgroundKey"
+
+        fun startWithView(
+            context: Context,
+            view: PaywallViewController,
+            key: String = UUID.randomUUID().toString(),
+            presentationStyleOverride: PaywallPresentationStyle? = null,
+        ) {
+            val viewStorageViewModel = Superwall.instance.viewStore()
+            viewStorageViewModel.storeView(key, view)
+
+            val intent =
+                Intent(context, SuperwallPaywallActivity::class.java).apply {
+                    putExtra(VIEW_KEY, key)
+                    putExtra(PRESENTATION_STYLE_KEY, presentationStyleOverride)
+                    putExtra(IS_LIGHT_BACKGROUND_KEY, view.paywall.backgroundColor.isLightColor())
+                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+                }
+
+            context.startActivity(intent)
+        }
+    }
+
+    private var contentView: View? = null
+    private var notificationPermissionCallback: NotificationPermissionCallback? = null
+
+    override fun setContentView(view: View) {
+        super.setContentView(view)
+        contentView = view
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+
+        // Show content behind the status bar
+        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        window.statusBarColor = Color.TRANSPARENT
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val isLightBackground = intent.getBooleanExtra(IS_LIGHT_BACKGROUND_KEY, false)
+            if (isLightBackground) {
+                window.insetsController?.let {
+                    it.setSystemBarsAppearance(
+                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                    )
+                }
+            }
+        }
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+
+        val key = intent.getStringExtra(VIEW_KEY)
+        if (key == null) {
+            finish() // Close the activity if there's no key
+            return
+        }
+
+        val viewStorageViewModel = Superwall.instance.viewStore()
+
+        val view =
+            viewStorageViewModel.retrieveView(key) as? PaywallViewController ?: run {
+                finish() // Close the activity if the view associated with the key is not found
+                return
+            }
+
+        (view.parent as? ViewGroup)?.removeView(view)
+        view.encapsulatingActivity = this
+
+        setContentView(view)
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    view.dismiss(
+                        result = PaywallResult.Declined(),
+                        closeReason = PaywallCloseReason.ManualClose,
+                    )
+                }
+            },
+        )
+
+        try {
+            supportActionBar?.hide()
+        } catch (e: Throwable) {
+        }
+
+        // TODO: handle animation and style from `presentationStyleOverride`
+        when (intent.getSerializableExtra(PRESENTATION_STYLE_KEY) as? PaywallPresentationStyle) {
+            PaywallPresentationStyle.PUSH -> {
+                overridePendingTransition(R.anim.slide_in_left, R.anim.slide_in_left)
+            }
+            PaywallPresentationStyle.DRAWER -> {
+            }
+            PaywallPresentationStyle.FULLSCREEN -> {
+            }
+            PaywallPresentationStyle.FULLSCREEN_NO_ANIMATION -> {
+            }
+            PaywallPresentationStyle.MODAL -> {
+            }
+            PaywallPresentationStyle.NONE -> {
+                // Do nothing
+            }
+            null -> {
+                // Do nothing
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val paywallVc = contentView as? PaywallViewController ?: return
+
+        if (paywallVc.isSafariVCPresented) {
+            paywallVc.isSafariVCPresented = false
+        }
+
+        paywallVc.viewWillAppear()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val paywallVc = contentView as? PaywallViewController ?: return
+
+        paywallVc.viewDidAppear()
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        val paywallVc = contentView as? PaywallViewController ?: return
+
+        CoroutineScope(Dispatchers.Main).launch {
+            paywallVc.viewWillDisappear()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        val paywallVc = contentView as? PaywallViewController ?: return
+
+        CoroutineScope(Dispatchers.Main).launch {
+            paywallVc.viewDidDisappear()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        (contentView?.parent as? ViewGroup)?.removeView(contentView)
+        // Clear reference to activity in the view
+        (contentView as? ActivityEncapsulatable)?.encapsulatingActivity = null
+
+        // Clear the reference to the contentView
+        contentView = null
+    }
+
+    //region Notifications
+    interface NotificationPermissionCallback {
+        fun onPermissionResult(granted: Boolean)
+    }
+
+    suspend fun attemptToScheduleNotifications(
+        notifications: List<LocalNotification>,
+        factory: DeviceHelperFactory,
+        context: Context,
+    ) = suspendCoroutine { continuation ->
+        if (notifications.isEmpty()) {
+            continuation.resume(Unit) // Resume immediately as there's nothing to schedule
+            return@suspendCoroutine
+        }
+
+        createNotificationChannel()
+
+        notificationPermissionCallback =
+            object : NotificationPermissionCallback {
+                override fun onPermissionResult(granted: Boolean) {
+                    if (granted) {
+                        NotificationScheduler.scheduleNotifications(
+                            notifications = notifications,
+                            factory = factory,
+                            context = context,
+                        )
+                    }
+                    continuation.resume(Unit) // Resume coroutine after processing
+                }
+            }
+
+        checkAndRequestNotificationPermissions(this, notificationPermissionCallback!!)
+    }
+
+    private fun createNotificationChannel() {
+        val importance = NotificationManager.IMPORTANCE_DEFAULT
+        val channel =
+            NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                NOTIFICATION_CHANNEL_NAME,
+                importance,
+            ).apply {
+                description = NOTIFICATION_CHANNEL_DESCRIPTION
+            }
+        channel.setShowBadge(false)
+        // Register the channel with the system
+        val notificationManager: NotificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun checkAndRequestNotificationPermissions(
+        context: Context,
+        callback: NotificationPermissionCallback,
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                if (!ActivityCompat.shouldShowRequestPermissionRationale(context as Activity, Manifest.permission.POST_NOTIFICATIONS)) {
+                    // First time asking or user previously denied without 'Don't ask again'
+                    ActivityCompat.requestPermissions(
+                        context,
+                        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                        REQUEST_CODE_NOTIFICATION_PERMISSION,
+                    )
+                } else {
+                    // Permission previously denied with 'Don't ask again'
+                    callback.onPermissionResult(false)
+                }
+            } else {
+                callback.onPermissionResult(true)
+            }
+        } else {
+            callback.onPermissionResult(areNotificationsEnabled(context))
+        }
+    }
+
+    private fun areNotificationsEnabled(context: Context): Boolean {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID)
+        if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
+            return false
+        }
+        return NotificationManagerCompat.from(context).areNotificationsEnabled()
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val isGranted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+            // Invoke the callback here
+            notificationPermissionCallback?.onPermissionResult(isGranted)
+        }
+    }
+    //endregion
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallStoreOwner.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallStoreOwner.kt
@@ -1,0 +1,21 @@
+package com.superwall.sdk.paywall.vc
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import com.superwall.sdk.paywall.vgc.ViewStorageViewModel
+
+internal object SuperwallStoreOwner : ViewModelStoreOwner {
+    override val viewModelStore: ViewModelStore = ViewModelStore()
+}
+
+internal class ViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ViewStorageViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ViewStorageViewModel() as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallStoreOwner.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallStoreOwner.kt
@@ -4,9 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
-import com.superwall.sdk.paywall.vgc.ViewStorageViewModel
 
-internal object SuperwallStoreOwner : ViewModelStoreOwner {
+internal class SuperwallStoreOwner : ViewModelStoreOwner {
     override val viewModelStore: ViewModelStore = ViewModelStore()
 }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorage.kt
@@ -1,0 +1,16 @@
+package com.superwall.sdk.paywall.vc
+
+import android.view.View
+
+interface ViewStorage {
+    val views: MutableMap<String, View>
+
+    fun storeView(
+        key: String,
+        view: View,
+    ) {
+        views[key] = view
+    }
+
+    fun retrieveView(key: String): View? = views.get(key)
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
@@ -1,8 +1,7 @@
-package com.superwall.sdk.paywall.vgc
+package com.superwall.sdk.paywall.vc
 
 import android.view.View
 import androidx.lifecycle.ViewModel
-import com.superwall.sdk.paywall.vc.ViewStorage
 
 /*
 * Stores already loaded or preloaded paywalls

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
@@ -1,0 +1,23 @@
+package com.superwall.sdk.paywall.vgc
+
+import android.view.View
+import androidx.lifecycle.ViewModel
+import com.superwall.sdk.paywall.vc.ViewStorage
+
+/*
+* Stores already loaded or preloaded paywalls
+* */
+internal class ViewStorageViewModel :
+    ViewModel(),
+    ViewStorage {
+    override val views = mutableMapOf<String, View>()
+
+    override fun storeView(
+        key: String,
+        view: View,
+    ) {
+        views[key] = view
+    }
+
+    override fun retrieveView(key: String): View? = views[key]
+}


### PR DESCRIPTION
## Changes in this pull request

- Since `ViewStorage` is a kotlin `object` singleton, it is possible it might lose state during configuration changes. Such an issue occurred on some tablets, so our `PaywallView` would not be found and it would close when the device would be rotated.
- Even if the rotation was survived, a view with a new key would be saved each time a paywall is launched.
- This adds a `ViewModelStore` to the SDK instance and migrates `ViewStorage`, so that our saved views can now properly survive configuration change or back navigation.
- Views are stored based on their `cacheKey` so that they can be properly restored.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)
