### PR TITLE
Fix timestamp issues with date using wrong formats, unify dates

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -64,6 +64,8 @@ import com.superwall.sdk.store.StoreKitManager
 import com.superwall.sdk.store.abstractions.transactions.GoogleBillingPurchaseTransaction
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.transactions.TransactionManager
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -71,6 +73,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
+import java.util.Date
 
 class DependencyContainer(
     val context: Context,
@@ -287,6 +290,7 @@ class DependencyContainer(
                     Superwall.instance.subscriptionStatus.value
                         .toString(),
                 "Content-Type" to "application/json",
+                "X-Current-Time" to dateFormat(DateUtils.ISO_MILLIS).format(Date())
             )
 
         return headers

--- a/superwall/src/main/java/com/superwall/sdk/models/events/EventData.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/events/EventData.kt
@@ -12,12 +12,14 @@ data class EventData(
     val id: String = UUID.randomUUID().toString(),
     @SerialName("event_name")
     val name: String,
+    @SerialName("parameters")
     val parameters: Map<
         String,
         @Serializable(with = AnySerializer::class)
         Any,
     >,
     @Serializable(with = DateSerializer::class)
+    @SerialName("created_at")
     val createdAt: Date,
 ) {
     companion object {

--- a/superwall/src/main/java/com/superwall/sdk/models/serialization/DateSerializer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/serialization/DateSerializer.kt
@@ -1,5 +1,7 @@
 package com.superwall.sdk.models.serialization
 
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
@@ -13,7 +15,7 @@ object DateSerializer : KSerializer<Date> {
     private val dateFormat =
         object : ThreadLocal<SimpleDateFormat>() {
             override fun initialValue() =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").apply {
+                dateFormat(DateUtils.ISO_MILLIS).apply {
                     timeZone = TimeZone.getTimeZone("UTC")
                 }
         }

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -27,6 +27,8 @@ import com.superwall.sdk.paywall.vc.web_view.templating.models.DeviceTemplate
 import com.superwall.sdk.storage.LastPaywallView
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.storage.TotalPaywallViews
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
@@ -205,7 +207,7 @@ class DeviceHelper(
         get() {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             val installDate = Date(packageInfo.firstInstallTime)
-            val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+            val formatter = dateFormat(DateUtils.SIMPLE)
             return formatter.format(installDate)
         }
 
@@ -240,42 +242,42 @@ class DeviceHelper(
 
     private val localDateFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+            val formatter = dateFormat(DateUtils.yyyy_MM_dd)
             formatter.timeZone = TimeZone.getDefault()
             return formatter
         }
 
     private val utcDateFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+            val formatter = dateFormat(DateUtils.yyyy_MM_dd)
             formatter.timeZone = TimeZone.getTimeZone("UTC")
             return formatter
         }
 
     private val utcTimeFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("HH:mm:ss", Locale.US)
+            val formatter = dateFormat(DateUtils.HH_mm_ss)
             formatter.timeZone = TimeZone.getTimeZone("UTC")
             return formatter
         }
 
     private val localDateTimeFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+            val formatter = dateFormat(DateUtils.ISO_SECONDS)
             formatter.timeZone = TimeZone.getDefault()
             return formatter
         }
 
     private val localTimeFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("HH:mm:ss", Locale.US)
+            val formatter = dateFormat(DateUtils.HH_mm_ss)
             formatter.timeZone = TimeZone.getDefault()
             return formatter
         }
 
     private val utcDateTimeFormat: SimpleDateFormat
         get() {
-            val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+            val formatter = dateFormat(DateUtils.ISO_SECONDS)
             formatter.timeZone = TimeZone.getTimeZone("UTC")
             return formatter
         }

--- a/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
@@ -7,6 +7,8 @@ import com.superwall.sdk.models.serialization.AnySerializer
 import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.models.triggers.ExperimentID
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializer
@@ -20,9 +22,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.io.File
 import java.security.MessageDigest
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import java.util.TimeZone
 
 enum class SearchPathDirectory {
@@ -251,7 +251,7 @@ object DisableVerboseEvents : Storable<Boolean> {
 @Serializer(forClass = Date::class)
 object DateSerializer : KSerializer<Date> {
     private val format =
-        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+        dateFormat(DateUtils.ISO_SECONDS_TIMEZONE).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -3,10 +3,11 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetails.PricingPhase
 import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
 import com.superwall.sdk.contrib.threeteen.AmountFormats
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.Transient
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.text.SimpleDateFormat
 import java.time.Period
 import java.util.Calendar
 import java.util.Currency
@@ -362,7 +363,7 @@ class RawStoreProduct(
 
     override val trialPeriodEndDateString by lazy {
         trialPeriodEndDate?.let {
-            val dateFormatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+            val dateFormatter = dateFormat(DateUtils.MMM_dd_yyyy)
             dateFormatter.format(it)
         } ?: ""
     }

--- a/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
@@ -1,0 +1,16 @@
+package com.superwall.sdk.utilities
+
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+internal object DateUtils {
+    val ISO_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    val ISO_SECONDS = "yyyy-MM-dd'T'HH:mm:ss"
+    val ISO_SECONDS_TIMEZONE = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    val SIMPLE = "yyyy-MM-dd HH:mm:ss"
+    val yyyy_MM_dd = "yyyy-MM-dd"
+    val HH_mm_ss = "HH:mm:ss"
+    val MMM_dd_yyyy = "MMM dd, yyyy"
+}
+
+internal fun dateFormat(format: String) = SimpleDateFormat(format, Locale.US)

--- a/superwall/src/test/java/com/superwall/sdk/models/serialization/DateSerializerTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/models/serialization/DateSerializerTest.kt
@@ -1,12 +1,12 @@
 package com.superwall.sdk.models.serialization
 
+import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.text.SimpleDateFormat
 import java.util.*
 import java.util.Calendar.*
 
@@ -19,7 +19,7 @@ class DateSerializerTest {
         val calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
                 time =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                    dateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
                         .apply {
                             timeZone = TimeZone.getTimeZone("UTC")
                         }.parse("2023-05-15T00:00:00.000Z")!!

--- a/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
@@ -8,6 +8,7 @@ import com.superwall.sdk.store.abstractions.product.OfferType
 import com.superwall.sdk.store.abstractions.product.RawStoreProduct
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.product.SubscriptionPeriod
+import com.superwall.sdk.utilities.DateUtils
 import kotlinx.coroutines.*
 import org.junit.Test
 import java.math.BigDecimal
@@ -340,7 +341,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assert(storeProduct.trialPeriodEndDateString == formattedDate)
     }
@@ -390,7 +391,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assert(storeProduct.trialPeriodEndDateString == formattedDate)
     }
@@ -440,7 +441,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assert(storeProduct.trialPeriodEndDateString == formattedDate)
     }
@@ -492,7 +493,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assert(storeProduct.trialPeriodEndDateString == formattedDate)
     }
@@ -545,7 +546,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assert(storeProduct.trialPeriodEndDateString == formattedDate)
     }


### PR DESCRIPTION
## Changes in this pull request

- Updates EventData's `created_at` and `parameters` to ensure naming is kept after obfuscation and mangling.
- Updates timestamps relying on user's locale to use US locale for formatting output
- Unifies usages of date formats.
- Fixes SW-2886 by adding `X-Current-Time` header

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)