### PR TITLE
Add configuration refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Adds the ability for the SDK to refresh the Superwall configuration every session start, subject to a feature flag.
 - Tracks a `config_refresh` Superwall event when the configuration is refreshed.
+- SW-2890: Adds `capabilities` to device attributes. This is a comma-separated list of capabilities the SDK has that you can target in audience filters. This release adds the `paywall_event_receiver` capability. This indicates that the paywall can receive transaction from the SDK.
 - SW-2902: Adds `abandoned_product_id` to a `transaction_abandon` event to use in audience filters. You can use this to show a paywall if a user abandons the transaction for a specific product.
-
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 1.2.1
+
+### Enhancements
+
+- Adds the ability for the SDK to refresh the Superwall configuration every session start, subject to a feature flag.
+- Tracks a `config_refresh` Superwall event when the configuration is refreshed.
+
 ## 1.2.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Adds the ability for the SDK to refresh the Superwall configuration every session start, subject to a feature flag.
 - Tracks a `config_refresh` Superwall event when the configuration is refreshed.
+- SW-2902: Adds `abandoned_product_id` to a `transaction_abandon` event to use in audience filters. You can use this to show a paywall if a user abandons the transaction for a specific product.
+
 
 ## 1.2.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ javascriptengineVersion = "1.0.0-beta01"
 kotlinxCoroutinesGuavaVersion = "1.8.1"
 leakcanaryAndroidVersion = "2.14"
 lifecycleProcessVersion = "2.8.1"
-mockk = "1.13.8"
 orchestratorVersion = "1.5.0"
 revenue_cat_version = "7.7.1"
 compose_version = "2024.05.00"
@@ -28,7 +27,7 @@ test_runner_version = "1.6.1"
 test_rules_version = "1.6.1"
 kotlin = "1.9.0"
 kotlinx_coroutines_core_version = "1.8.1"
-mockk_version = "1.12.8"
+mockk_version = "1.13.12"
 threetenbp_version = "1.6.8"
 uiautomator_version = "2.3.0"
 workRuntimeKtx_version = "2.9.0"
@@ -85,7 +84,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson_version" }
 # Test
 junit = { module = "junit:junit", version.ref = "junit_version" }
 kotlinx_coroutines_test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_coroutines_test_version" }
-mockk = { module = "io.mockk:mockk", version.ref = "mockk_version" }
+mockk_core = { module = "io.mockk:mockk", version.ref = "mockk_version" }
 
 # Test (Android)
 test_ext_junit = { module = "androidx.test.ext:junit", version.ref = "test_ext_junit_version" }
@@ -94,6 +93,7 @@ test_runner = { module = "androidx.test:runner", version.ref = "test_runner_vers
 test_core = { module = "androidx.test:core", version.ref = "test_runner_version" }
 test_rules = { module = "androidx.test:rules", version.ref = "test_rules_version" }
 ui_test_junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+mockk_android = { module = "io.mockk:mockk-android", version.ref = "mockk_version" }
 
 # Debug
 ui_tooling = { module = "androidx.compose.ui:ui-tooling" }

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -81,6 +81,7 @@ android {
 
     packaging {
         resources.excludes += "META-INF/LICENSE.md"
+        resources.excludes += "META-INF/LICENSE-notice.md"
     }
 
     publishing {
@@ -211,12 +212,11 @@ dependencies {
     // Test
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-    // ??? Not sure if we need this
-    // testImplementation("org.json:json:20210307")
+    testImplementation(libs.mockk.core)
 
     // Test (Android)
     androidTestImplementation(libs.test.ext.junit)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.mockk.android)
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
@@ -16,6 +16,7 @@ import com.superwall.sdk.paywall.presentation.rule_logic.javascript.SandboxJavas
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.storage.StorageMock
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
@@ -56,14 +57,12 @@ class ExpressionEvaluatorInstrumentedTest {
             sandbox = null
         }
 
-    private fun evaluatorFor(
-        storage: Storage,
-        factory: RuleAttributesFactory,
-    ) = SandboxJavascriptEvaluator(
-        sandbox ?: error("Sandbox not initialized"),
-        factory = factory,
-        storage = storage,
-    )
+    private fun CoroutineScope.evaluatorFor(storage: Storage) =
+        SandboxJavascriptEvaluator(
+            sandbox ?: error("Sandbox not initialized"),
+            storage = storage,
+            ioScope = this,
+        )
 
     @Test
     fun test_happy_path_evaluator() =
@@ -77,7 +76,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -130,7 +128,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -224,7 +221,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -326,7 +322,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -368,21 +363,4 @@ class ExpressionEvaluatorInstrumentedTest {
 
             assert(result == TriggerRuleOutcome.match(rule = rule))
         }
-
-    suspend fun runWithRule(rule: TriggerRule) {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val ruleAttributes = RuleAttributeFactoryBuilder()
-        val storage = StorageMock(context = context)
-
-        val expressionEvaluator =
-            ExpressionEvaluator(
-                evaluator =
-                    evaluatorFor(
-                        factory = ruleAttributes,
-                        storage = storage,
-                    ),
-                storage = storage,
-                factory = ruleAttributes,
-            )
-    }
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvaluatorTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvaluatorTest.kt
@@ -1,0 +1,70 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.javascript
+
+import android.webkit.WebView
+import androidx.javascriptengine.JavaScriptSandbox
+import androidx.javascriptengine.SandboxDeadException
+import androidx.test.platform.app.InstrumentationRegistry
+import com.superwall.sdk.models.triggers.TriggerRule
+import com.superwall.sdk.storage.Storage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultJavascriptEvaluatorTest {
+    fun ctx() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun evaulate_succesfully_with_sandbox() =
+        runTest {
+            val storage = mockk<Storage>()
+            mockkStatic(WebView::class) {
+                every { WebView.getCurrentWebViewPackage() } returns null
+            }
+            val evaulator =
+                DefaultJavascriptEvalutor(
+                    this,
+                    CoroutineScope(Dispatchers.Main),
+                    ctx(),
+                    storage = storage,
+                )
+            evaulator.evaluate("console.assert(true);", TriggerRule.stub())
+            evaulator.teardown()
+        }
+
+    @Test
+    fun fail_evaluating_with_sandbox_and_fallback_is_used() =
+        runTest {
+            val storage = mockk<Storage>()
+
+            val sandbox = JavaScriptSandbox.createConnectedInstanceAsync(ctx()).await()
+
+            val mockSand =
+                spyk(sandbox) {
+                    every { createIsolate() } throws SandboxDeadException()
+                }
+            val evaulator =
+                DefaultJavascriptEvalutor(
+                    this,
+                    CoroutineScope(Dispatchers.Main),
+                    ctx(),
+                    storage = storage,
+                    createSandbox = {
+                        sandbox
+                    },
+                )
+            launch(Dispatchers.IO) {
+                delay(100)
+                evaulator.evaluate("console.assert(true);", TriggerRule.stub())
+            }
+            mockSand.killImmediatelyOnThread()
+            evaulator.teardown()
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -702,6 +702,12 @@ sealed class InternalSuperwallEvent(
         }
     }
 
+    object ConfigRefresh : InternalSuperwallEvent(SuperwallEvent.ConfigRefresh) {
+        override val customParameters: Map<String, Any> = emptyMap()
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
+    }
+
     object Reset : InternalSuperwallEvent(SuperwallEvent.Reset) {
         override val customParameters: Map<String, Any> = emptyMap()
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -440,7 +440,13 @@ sealed class InternalSuperwallEvent(
 
         override val customParameters: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.customParams().let {
+                    if (superwallEvent is SuperwallEvent.TransactionAbandon) {
+                        it.plus("abandoned_product_id" to (product?.productIdentifier ?: ""))
+                    } else {
+                        it
+                    }
+                }
             }
 
         override val superwallEvent: SuperwallEvent

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -358,6 +358,12 @@ sealed class SuperwallEvent {
             get() = "survey_close"
     }
 
+    // When a configuration is refreshed successfully
+    object ConfigRefresh : SuperwallEvent() {
+        override val rawName: String
+            get() = "config_refresh"
+    }
+
     // When Superwall.instance.reset is called
     object Reset : SuperwallEvent() {
         override val rawName: String

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -198,19 +198,19 @@ sealed class SuperwallEvent {
     sealed class Restore : SuperwallEvent() {
         object Start : Restore() {
             override val rawName: String
-                get() = "restore_start"
+                get() = SuperwallEvents.RestoreStart.rawName
         }
 
         data class Fail(
             val reason: String,
         ) : Restore() {
             override val rawName: String
-                get() = "restore_fail"
+                get() = SuperwallEvents.RestoreFail.rawName
         }
 
         object Complete : Restore() {
             override val rawName: String
-                get() = "restore_complete"
+                get() = SuperwallEvents.RestoreComplete.rawName
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -42,4 +42,7 @@ enum class SuperwallEvents(
     PaywallProductsLoadFail("paywallProductsLoad_fail"),
     PaywallProductsLoadComplete("paywallProductsLoad_complete"),
     PaywallPresentationRequest("paywallPresentationRequest"),
+    RestoreStart("restore_start"),
+    RestoreFail("restore_fail"),
+    RestoreComplete("restore_complete"),
 }

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -361,6 +361,7 @@ open class ConfigManager(
         try {
             val newConfig =
                 network.getConfig {}
+            paywallManager.resetPaywallRequestCache()
             removeUnusedPaywallVCsFromCache(oldConfig, newConfig)
             processConfig(newConfig)
             configState.update { Result.Success(ConfigState.Retrieved(newConfig)) }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -31,6 +31,7 @@ import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.network.Api
+import com.superwall.sdk.network.JsonFactory
 import com.superwall.sdk.network.Network
 import com.superwall.sdk.network.device.DeviceHelper
 import com.superwall.sdk.network.device.DeviceInfo
@@ -95,7 +96,8 @@ class DependencyContainer(
     ConfigManager.Factory,
     AppSessionManager.Factory,
     DebugView.Factory,
-    JavascriptEvaluator.Factory {
+    JavascriptEvaluator.Factory,
+    JsonFactory {
     var network: Network
     override lateinit var api: Api
     override lateinit var deviceHelper: DeviceHelper
@@ -508,6 +510,6 @@ class DependencyContainer(
     override suspend fun makeSuperwallOptions(): SuperwallOptions = configManager.options
 
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
-
+      
     override suspend fun provideJavascriptEvaluator(context: Context) = evaluator
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -17,6 +17,7 @@ import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.network.Api
+import com.superwall.sdk.network.JsonFactory
 import com.superwall.sdk.network.device.DeviceHelper
 import com.superwall.sdk.network.device.DeviceInfo
 import com.superwall.sdk.paywall.manager.PaywallViewCache
@@ -33,7 +34,7 @@ import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import kotlinx.coroutines.flow.StateFlow
 
-interface ApiFactory {
+interface ApiFactory : JsonFactory {
     // TODO: Think of an alternative way such that we don't need to do this:
     var api: Api
     var storage: Storage

--- a/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
@@ -38,6 +38,7 @@ data class Config(
     val featureFlags: FeatureFlags
         get() =
             FeatureFlags(
+                enableConfigRefresh = rawFeatureFlags.find { it.key == "enable_config_refresh" }?.enabled ?: false,
                 enableSessionEvents =
                     rawFeatureFlags.find { it.key == "enable_session_events" }?.enabled
                         ?: false,

--- a/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
@@ -11,6 +11,7 @@ data class RawFeatureFlag(
 
 @Serializable
 data class FeatureFlags(
+    @SerialName("enable_config_refresh") var enableConfigRefresh: Boolean = true,
     @SerialName("enable_session_events") var enableSessionEvents: Boolean,
     @SerialName("enable_postback") var enablePostback: Boolean,
     @SerialName("enable_userid_seed") var enableUserIdSeed: Boolean,

--- a/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
@@ -11,7 +11,7 @@ data class RawFeatureFlag(
 
 @Serializable
 data class FeatureFlags(
-    @SerialName("enable_config_refresh") var enableConfigRefresh: Boolean = true,
+    @SerialName("enable_config_refresh") var enableConfigRefresh: Boolean = false,
     @SerialName("enable_session_events") var enableSessionEvents: Boolean,
     @SerialName("enable_postback") var enablePostback: Boolean,
     @SerialName("enable_userid_seed") var enableUserIdSeed: Boolean,

--- a/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Endpoint.kt
@@ -15,8 +15,6 @@ import com.superwall.sdk.models.postback.PostBackResponse
 import com.superwall.sdk.models.postback.Postback
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonNamingStrategy
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.*
@@ -96,12 +94,7 @@ data class Endpoint<Response : SerializableEntity>(
             eventsRequest: EventsRequest,
             factory: ApiFactory,
         ): Endpoint<EventsResponse> {
-            val json =
-                Json {
-                    encodeDefaults = true
-                    namingStrategy = JsonNamingStrategy.SnakeCase
-                }
-            val bodyData = json.encodeToString(eventsRequest).toByteArray()
+            val bodyData = factory.json().encodeToString(eventsRequest).toByteArray()
             val collectorHost = factory.api.collector.host
 
             return Endpoint<EventsResponse>(
@@ -154,11 +147,7 @@ data class Endpoint<Response : SerializableEntity>(
             confirmableAssignments: AssignmentPostback,
             factory: ApiFactory,
         ): Endpoint<ConfirmedAssignmentResponse> {
-            val json =
-                Json {
-                    encodeDefaults = true
-                    namingStrategy = JsonNamingStrategy.SnakeCase
-                }
+            val json = factory.json()
             val bodyData = json.encodeToString(confirmableAssignments).toByteArray()
             val baseHost = factory.api.base.host
 
@@ -178,11 +167,7 @@ data class Endpoint<Response : SerializableEntity>(
             postback: Postback,
             factory: ApiFactory,
         ): Endpoint<PostBackResponse> {
-            val json =
-                Json {
-                    encodeDefaults = true
-                    namingStrategy = JsonNamingStrategy.SnakeCase
-                }
+            val json = factory.json()
             val bodyData = json.encodeToString(postback).toByteArray()
             val collectorHost = factory.api.collector.host
 
@@ -344,7 +329,7 @@ data class Endpoint<Response : SerializableEntity>(
 //                }
 //            }
 //            val baseHost = factory.api.base.host
-//
+// -m
 //            return Endpoint(
 //                components = Components(
 //                    host = baseHost,

--- a/superwall/src/main/java/com/superwall/sdk/network/JsonFactory.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/JsonFactory.kt
@@ -1,0 +1,12 @@
+package com.superwall.sdk.network
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+
+interface JsonFactory {
+    fun json() =
+        Json {
+            encodeDefaults = true
+            namingStrategy = JsonNamingStrategy.SnakeCase
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
@@ -1,0 +1,38 @@
+package com.superwall.sdk.network.device
+
+import com.superwall.sdk.analytics.superwall.SuperwallEvents
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+
+@Serializable
+internal sealed class Capability(
+    @SerialName("name")
+    val name: String,
+) {
+    @Serializable
+    @SerialName("paywall_event_receiver")
+    class PaywallEventReceiver : Capability("paywall_event_receiver") {
+        @SerialName("event_names")
+        val eventNames =
+            listOf(
+                SuperwallEvents.TransactionStart,
+                SuperwallEvents.TransactionRestore,
+                SuperwallEvents.TransactionComplete,
+                SuperwallEvents.RestoreStart,
+                SuperwallEvents.RestoreFail,
+                SuperwallEvents.RestoreComplete,
+                SuperwallEvents.TransactionFail,
+                SuperwallEvents.TransactionAbandon,
+                SuperwallEvents.TransactionTimeout,
+                SuperwallEvents.PaywallOpen,
+                SuperwallEvents.PaywallClose,
+            ).map { it.rawName }
+    }
+}
+
+internal fun List<Capability>.toJson(json: Json): JsonElement = json.encodeToJsonElement(this)
+
+internal fun List<Capability>.namesCommaSeparated(): String = this.joinToString(",") { it.name }

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -22,6 +22,7 @@ import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.geo.GeoInfo
+import com.superwall.sdk.network.JsonFactory
 import com.superwall.sdk.network.Network
 import com.superwall.sdk.paywall.vc.web_view.templating.models.DeviceTemplate
 import com.superwall.sdk.storage.LastPaywallView
@@ -55,7 +56,8 @@ class DeviceHelper(
 ) {
     interface Factory :
         IdentityInfoFactory,
-        LocaleIdentifierFactory
+        LocaleIdentifierFactory,
+        JsonFactory
 
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -415,6 +417,7 @@ class DeviceHelper(
                 )
                 null
             }
+        val capabilities: List<Capability> = listOf(Capability.PaywallEventReceiver())
         val deviceTemplate =
             DeviceTemplate(
                 publicApiKey = storage.apiKey,
@@ -467,6 +470,8 @@ class DeviceHelper(
                 ipCity = geo?.city,
                 ipContinent = geo?.continent,
                 ipTimezone = geo?.timezone,
+                capabilities = capabilities.map { it.name },
+                capabilitiesConfig = capabilities.toJson(factory.json()),
             )
 
         return deviceTemplate.toDictionary()

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
@@ -129,4 +129,8 @@ class PaywallManager(
 
         return paywallView
     }
+
+    internal fun resetPaywallRequestCache() {
+        paywallRequestManager.resetCache()
+    }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
@@ -1,0 +1,134 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.javascript
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.javascriptengine.JavaScriptSandbox
+import androidx.javascriptengine.SandboxDeadException
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
+import com.superwall.sdk.models.triggers.TriggerRule
+import com.superwall.sdk.models.triggers.TriggerRuleOutcome
+import com.superwall.sdk.models.triggers.UnmatchedRule
+import com.superwall.sdk.storage.Storage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+
+class DefaultJavascriptEvalutor(
+    private val ioScope: CoroutineScope,
+    private val uiScope: CoroutineScope,
+    private val context: Context,
+    private val storage: Storage,
+    private val createSandbox: suspend (ctx: Context) -> JavaScriptSandbox = {
+        JavaScriptSandbox.createConnectedInstanceAsync(it).await()
+    },
+) : JavascriptEvaluator {
+    private val mutex = Mutex()
+    private var eval: Deferred<JavascriptEvaluator>? = null
+
+    /*
+     * Tries to evaluate JS using existing evaluator. If it is broken, tears it down and creates
+     * tries to execute it again, falling back to a WebView if that fails.
+     * */
+    override suspend fun evaluate(
+        base64params: String,
+        rule: TriggerRule,
+    ): TriggerRuleOutcome =
+        try {
+            // Try to evaluate with the existing evaluator
+            createEvaluatorIfDoesntExist().evaluate(base64params, rule)
+        } catch (throwable: SandboxDeadException) {
+            // If evaluation failed, try teardown and recreate evaluator
+            teardown()
+            tryEvaluateWithFallback(base64params, rule)
+        } catch (e: Exception) {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.superwallCore,
+                message = "Failed to evaluate rule with fallback: ${e.message}",
+            )
+            TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
+        }
+
+    override fun teardown() {
+        runBlocking {
+            try {
+                eval?.await()?.teardown()
+            } catch (e: Exception) {
+                Logger.debug(
+                    logLevel = LogLevel.error,
+                    scope = LogScope.superwallCore,
+                    message = "Failed to teardown evaluator: ${e.message}",
+                )
+            }
+            // Clear the existing evaluator and try with fallback to webview
+            eval = null
+        }
+    }
+
+    private suspend fun createNewEvaluator(context: Context): JavascriptEvaluator =
+        when {
+            JavaScriptSandbox.isSupported() -> createSandboxEvaluator(context)
+            WebView.getCurrentWebViewPackage() != null -> createWebViewEvaluator(context)
+            else -> NoSupportedEvaluator
+        }
+
+    private suspend fun createSandboxEvaluator(context: Context): JavascriptEvaluator =
+        try {
+            val sandbox = createSandbox(context)
+            SandboxJavascriptEvaluator(sandbox, ioScope, storage)
+        } catch (e: Exception) {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.superwallCore,
+                message = "Failed to create javascript sandbox evaluator: ${e.message}",
+            )
+            createWebViewEvaluator(context) // Fallback to WebView
+        }
+
+    private suspend fun createWebViewEvaluator(context: Context): JavascriptEvaluator =
+        uiScope
+            .async {
+                WebviewJavascriptEvaluator(WebView(context), uiScope, storage)
+            }.await()
+
+    // Tries to create a JSSandbox and if it fails, it falls back to a WebView
+    private suspend fun tryEvaluateWithFallback(
+        base64params: String,
+        rule: TriggerRule,
+    ): TriggerRuleOutcome =
+        try {
+            createEvaluatorIfDoesntExist().evaluate(base64params, rule)
+        } catch (e: Exception) {
+            teardown()
+            createEvaluatorIfDoesntExist {
+                createWebViewEvaluator(context)
+            }.evaluate(base64params, rule)
+        }
+
+    private suspend fun createEvaluatorIfDoesntExist(
+        invoke: suspend () -> JavascriptEvaluator = {
+            createNewEvaluator(context)
+        },
+    ): JavascriptEvaluator {
+        mutex.lock()
+        val current = eval
+        val evaluator =
+            if (current == null) {
+                val call =
+                    ioScope.async {
+                        invoke()
+                    }
+                eval = call
+                call.await()
+            } else {
+                current.await()
+            }
+        mutex.unlock()
+        return evaluator
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
@@ -1,7 +1,6 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.javascript
 
 import androidx.javascriptengine.JavaScriptSandbox
-import com.superwall.sdk.dependencies.RuleAttributesFactory
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
@@ -11,43 +10,46 @@ import com.superwall.sdk.models.triggers.UnmatchedRule
 import com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator.SDKJS
 import com.superwall.sdk.paywall.presentation.rule_logic.tryToMatchOccurrence
 import com.superwall.sdk.storage.Storage
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 internal class SandboxJavascriptEvaluator(
-    val jsSandbox: JavaScriptSandbox,
-    val factory: RuleAttributesFactory,
-    val storage: Storage,
+    private val jsSandbox: JavaScriptSandbox,
+    private val ioScope: CoroutineScope,
+    private val storage: Storage,
 ) : JavascriptEvaluator {
     override suspend fun evaluate(
         base64params: String,
         rule: TriggerRule,
-    ): TriggerRuleOutcome {
-        val jsIsolate = jsSandbox?.createIsolate()
-        jsIsolate?.addOnTerminatedCallback {
-            Logger.debug(
-                logLevel = LogLevel.error,
-                scope = LogScope.superwallCore,
-                message = "$it",
-            )
+    ): TriggerRuleOutcome =
+        withContext(ioScope.coroutineContext) {
+            val jsIsolate = jsSandbox.createIsolate()
+            jsIsolate.addOnTerminatedCallback {
+                Logger.debug(
+                    logLevel = LogLevel.error,
+                    scope = LogScope.superwallCore,
+                    message = "$it",
+                )
+            }
+
+            val resultFuture = jsIsolate.evaluateJavaScriptAsync("$SDKJS\n $base64params")
+
+            val result = resultFuture.await()
+            jsIsolate.close()
+
+            if (result.isNullOrEmpty()) {
+                TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
+            } else {
+                val expressionMatched = result == "true"
+                rule.tryToMatchOccurrence(storage, expressionMatched)
+            }
         }
-
-        val resultFuture = jsIsolate?.evaluateJavaScriptAsync("$SDKJS\n $base64params")
-
-        val result = resultFuture?.await()
-        jsIsolate?.close()
-
-        if (result.isNullOrEmpty()) {
-            return TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
-        } else {
-            val expressionMatched = result == "true"
-            return rule.tryToMatchOccurrence(storage, expressionMatched)
-        }
-    }
 
     override fun teardown() {
         runBlocking {
-            jsSandbox?.close()
+            jsSandbox.close()
         }
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallRequestManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallRequestManager.kt
@@ -265,4 +265,8 @@ class PaywallRequestManager(
 
             return@withContext paywall
         }
+
+    internal fun resetCache() {
+        paywallsByHash.clear()
+    }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
@@ -46,7 +46,6 @@ object TemplateLogic {
                 json.encodeToString(freeTrialTemplate),
 //            json.encodeToString(swProductTemplate)
             )
-
         val templatesString = "[" + encodedTemplates.joinToString(",") + "]"
         val templatesData = templatesString.toByteArray(Charsets.UTF_8)
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
@@ -1,9 +1,11 @@
 package com.superwall.sdk.paywall.vc.web_view.templating.models
 
 import com.superwall.sdk.models.serialization.jsonStringToType
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class DeviceTemplate(
@@ -55,6 +57,10 @@ data class DeviceTemplate(
     val ipCity: String?,
     val ipContinent: String?,
     val ipTimezone: String?,
+    @SerialName("capabilities")
+    val capabilities: List<String>,
+    @SerialName("capabilities_config")
+    val capabilitiesConfig: JsonElement,
 ) {
     fun toDictionary(): Map<String, Any> {
         val json = Json { encodeDefaults = true }


### PR DESCRIPTION
## Changes in this pull request

- Adds the ability for the SDK to refresh the Superwall configuration every session start, subject to a feature flag.
- Tracks a `config_refresh` Superwall event when the configuration is refreshed.

### Checklist

- [ ] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)