### PR TITLE
Ensure sandbox gets recreated and uses fallback in case of crashing

### DIFF
--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorInstrumentedTest.kt
@@ -16,6 +16,7 @@ import com.superwall.sdk.paywall.presentation.rule_logic.javascript.SandboxJavas
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.storage.StorageMock
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
@@ -56,14 +57,12 @@ class ExpressionEvaluatorInstrumentedTest {
             sandbox = null
         }
 
-    private fun evaluatorFor(
-        storage: Storage,
-        factory: RuleAttributesFactory,
-    ) = SandboxJavascriptEvaluator(
-        sandbox ?: error("Sandbox not initialized"),
-        factory = factory,
-        storage = storage,
-    )
+    private fun CoroutineScope.evaluatorFor(storage: Storage) =
+        SandboxJavascriptEvaluator(
+            sandbox ?: error("Sandbox not initialized"),
+            storage = storage,
+            ioScope = this,
+        )
 
     @Test
     fun test_happy_path_evaluator() =
@@ -77,7 +76,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -130,7 +128,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -224,7 +221,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -326,7 +322,6 @@ class ExpressionEvaluatorInstrumentedTest {
                 ExpressionEvaluator(
                     evaluator =
                         evaluatorFor(
-                            factory = ruleAttributes,
                             storage = storage,
                         ),
                     storage = storage,
@@ -368,21 +363,4 @@ class ExpressionEvaluatorInstrumentedTest {
 
             assert(result == TriggerRuleOutcome.match(rule = rule))
         }
-
-    suspend fun runWithRule(rule: TriggerRule) {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val ruleAttributes = RuleAttributeFactoryBuilder()
-        val storage = StorageMock(context = context)
-
-        val expressionEvaluator =
-            ExpressionEvaluator(
-                evaluator =
-                    evaluatorFor(
-                        factory = ruleAttributes,
-                        storage = storage,
-                    ),
-                storage = storage,
-                factory = ruleAttributes,
-            )
-    }
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvaluatorTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvaluatorTest.kt
@@ -1,0 +1,70 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.javascript
+
+import android.webkit.WebView
+import androidx.javascriptengine.JavaScriptSandbox
+import androidx.javascriptengine.SandboxDeadException
+import androidx.test.platform.app.InstrumentationRegistry
+import com.superwall.sdk.models.triggers.TriggerRule
+import com.superwall.sdk.storage.Storage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultJavascriptEvaluatorTest {
+    fun ctx() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun evaulate_succesfully_with_sandbox() =
+        runTest {
+            val storage = mockk<Storage>()
+            mockkStatic(WebView::class) {
+                every { WebView.getCurrentWebViewPackage() } returns null
+            }
+            val evaulator =
+                DefaultJavascriptEvalutor(
+                    this,
+                    CoroutineScope(Dispatchers.Main),
+                    ctx(),
+                    storage = storage,
+                )
+            evaulator.evaluate("console.assert(true);", TriggerRule.stub())
+            evaulator.teardown()
+        }
+
+    @Test
+    fun fail_evaluating_with_sandbox_and_fallback_is_used() =
+        runTest {
+            val storage = mockk<Storage>()
+
+            val sandbox = JavaScriptSandbox.createConnectedInstanceAsync(ctx()).await()
+
+            val mockSand =
+                spyk(sandbox) {
+                    every { createIsolate() } throws SandboxDeadException()
+                }
+            val evaulator =
+                DefaultJavascriptEvalutor(
+                    this,
+                    CoroutineScope(Dispatchers.Main),
+                    ctx(),
+                    storage = storage,
+                    createSandbox = {
+                        sandbox
+                    },
+                )
+            launch(Dispatchers.IO) {
+                delay(100)
+                evaulator.evaluate("console.assert(true);", TriggerRule.stub())
+            }
+            mockSand.killImmediatelyOnThread()
+            evaulator.teardown()
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
@@ -1,0 +1,130 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.javascript
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.javascriptengine.JavaScriptSandbox
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
+import com.superwall.sdk.models.triggers.TriggerRule
+import com.superwall.sdk.models.triggers.TriggerRuleOutcome
+import com.superwall.sdk.models.triggers.UnmatchedRule
+import com.superwall.sdk.storage.Storage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+
+class DefaultJavascriptEvalutor(
+    private val ioScope: CoroutineScope,
+    private val uiScope: CoroutineScope,
+    private val context: Context,
+    private val storage: Storage,
+) : JavascriptEvaluator {
+    private val mutex = Mutex()
+    private var eval: Deferred<JavascriptEvaluator>? = null
+
+    /*
+     * Tries to evaluate JS using existing evaluator. If it is broken, tears it down and creates
+     * tries to execute it again, falling back to a WebView if that fails.
+     * */
+    override suspend fun evaluate(
+        base64params: String,
+        rule: TriggerRule,
+    ): TriggerRuleOutcome =
+        try {
+            // Try to evaluate with the existing evaluator
+            createEvaluatorIfDoesntExist().evaluate(base64params, rule)
+        } catch (throwable: Throwable) {
+            // If evaluation failed, try teardown and recreate evaluator
+            teardown()
+            tryEvaluateWithFallback(base64params, rule)
+        } catch (e: Throwable) {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.superwallCore,
+                message = "Failed to evaluate rule with fallback: ${e.message}",
+            )
+            TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
+        }
+
+    override fun teardown() {
+        ioScope.launch {
+            try {
+                eval?.await()?.teardown()
+            } catch (e: Exception) {
+                Logger.debug(
+                    logLevel = LogLevel.error,
+                    scope = LogScope.superwallCore,
+                    message = "Failed to teardown evaluator: ${e.message}",
+                )
+            }
+            // Clear the existing evaluator and try with fallback to webview
+            eval = null
+        }
+    }
+
+    private suspend fun createNewEvaluator(context: Context): JavascriptEvaluator =
+        when {
+            JavaScriptSandbox.isSupported() -> createSandboxEvaluator(context)
+            WebView.getCurrentWebViewPackage() != null -> createWebViewEvaluator(context)
+            else -> NoSupportedEvaluator
+        }
+
+    private suspend fun createSandboxEvaluator(context: Context): JavascriptEvaluator =
+        try {
+            val sandbox = JavaScriptSandbox.createConnectedInstanceAsync(context).await()
+            SandboxJavascriptEvaluator(sandbox, ioScope, storage)
+        } catch (e: Exception) {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.superwallCore,
+                message = "Failed to create javascript sandbox evaluator: ${e.message}",
+            )
+            createWebViewEvaluator(context) // Fallback to WebView
+        }
+
+    private suspend fun createWebViewEvaluator(context: Context): JavascriptEvaluator =
+        uiScope
+            .async {
+                WebviewJavascriptEvaluator(WebView(context), uiScope, storage)
+            }.await()
+
+    // Tries to create a JSSandbox and if it fails, it falls back to a WebView
+    private suspend fun tryEvaluateWithFallback(
+        base64params: String,
+        rule: TriggerRule,
+    ): TriggerRuleOutcome =
+        try {
+            createEvaluatorIfDoesntExist().evaluate(base64params, rule)
+        } catch (e: Throwable) {
+            teardown()
+            createEvaluatorIfDoesntExist {
+                createWebViewEvaluator(context)
+            }.evaluate(base64params, rule)
+        }
+
+    private suspend fun createEvaluatorIfDoesntExist(
+        invoke: suspend () -> JavascriptEvaluator = {
+            createNewEvaluator(context)
+        },
+    ): JavascriptEvaluator {
+        mutex.lock(this)
+        val current = eval
+        val evaluator =
+            if (current == null) {
+                val call =
+                    ioScope.async {
+                        invoke()
+                    }
+                eval = call
+                call.await()
+            } else {
+                current.await()
+            }
+        mutex.unlock(this)
+        return evaluator
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
@@ -1,7 +1,6 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.javascript
 
 import androidx.javascriptengine.JavaScriptSandbox
-import com.superwall.sdk.dependencies.RuleAttributesFactory
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
@@ -11,39 +10,42 @@ import com.superwall.sdk.models.triggers.UnmatchedRule
 import com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator.SDKJS
 import com.superwall.sdk.paywall.presentation.rule_logic.tryToMatchOccurrence
 import com.superwall.sdk.storage.Storage
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 internal class SandboxJavascriptEvaluator(
-    val jsSandbox: JavaScriptSandbox,
-    val factory: RuleAttributesFactory,
-    val storage: Storage,
+    private val jsSandbox: JavaScriptSandbox,
+    private val ioScope: CoroutineScope,
+    private val storage: Storage,
 ) : JavascriptEvaluator {
     override suspend fun evaluate(
         base64params: String,
         rule: TriggerRule,
-    ): TriggerRuleOutcome {
-        val jsIsolate = jsSandbox?.createIsolate()
-        jsIsolate?.addOnTerminatedCallback {
-            Logger.debug(
-                logLevel = LogLevel.error,
-                scope = LogScope.superwallCore,
-                message = "$it",
-            )
+    ): TriggerRuleOutcome =
+        withContext(ioScope.coroutineContext) {
+            val jsIsolate = jsSandbox?.createIsolate()
+            jsIsolate?.addOnTerminatedCallback {
+                Logger.debug(
+                    logLevel = LogLevel.error,
+                    scope = LogScope.superwallCore,
+                    message = "$it",
+                )
+            }
+
+            val resultFuture = jsIsolate?.evaluateJavaScriptAsync("$SDKJS\n $base64params")
+
+            val result = resultFuture?.await()
+            jsIsolate?.close()
+
+            if (result.isNullOrEmpty()) {
+                TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
+            } else {
+                val expressionMatched = result == "true"
+                rule.tryToMatchOccurrence(storage, expressionMatched)
+            }
         }
-
-        val resultFuture = jsIsolate?.evaluateJavaScriptAsync("$SDKJS\n $base64params")
-
-        val result = resultFuture?.await()
-        jsIsolate?.close()
-
-        if (result.isNullOrEmpty()) {
-            return TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
-        } else {
-            val expressionMatched = result == "true"
-            return rule.tryToMatchOccurrence(storage, expressionMatched)
-        }
-    }
 
     override fun teardown() {
         runBlocking {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/SandboxJavascriptEvaluator.kt
@@ -25,8 +25,8 @@ internal class SandboxJavascriptEvaluator(
         rule: TriggerRule,
     ): TriggerRuleOutcome =
         withContext(ioScope.coroutineContext) {
-            val jsIsolate = jsSandbox?.createIsolate()
-            jsIsolate?.addOnTerminatedCallback {
+            val jsIsolate = jsSandbox.createIsolate()
+            jsIsolate.addOnTerminatedCallback {
                 Logger.debug(
                     logLevel = LogLevel.error,
                     scope = LogScope.superwallCore,
@@ -34,10 +34,10 @@ internal class SandboxJavascriptEvaluator(
                 )
             }
 
-            val resultFuture = jsIsolate?.evaluateJavaScriptAsync("$SDKJS\n $base64params")
+            val resultFuture = jsIsolate.evaluateJavaScriptAsync("$SDKJS\n $base64params")
 
-            val result = resultFuture?.await()
-            jsIsolate?.close()
+            val result = resultFuture.await()
+            jsIsolate.close()
 
             if (result.isNullOrEmpty()) {
                 TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
@@ -49,7 +49,7 @@ internal class SandboxJavascriptEvaluator(
 
     override fun teardown() {
         runBlocking {
-            jsSandbox?.close()
+            jsSandbox.close()
         }
     }
 }


### PR DESCRIPTION
## Changes in this pull request

- Adds `DefaultJavascriptEvaluator` that serves as a default implementation containing both sandbox and fallback.
- Ensures `JavascriptSandbox` gets recreated and evaluation is retried in case of crashing.
- Ensures `WebviewJavascriptEvaluator` is used in case of repeated failures as a fallback.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)