### PR TITLE
Add abandoned product ID to TransactionAbandon events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Adds the ability for the SDK to refresh the Superwall configuration every session start, subject to a feature flag.
 - Tracks a `config_refresh` Superwall event when the configuration is refreshed.
+- SW-2902: Adds `abandoned_product_id` to a `transaction_abandon` event to use in audience filters. You can use this to show a paywall if a user abandons the transaction for a specific product.
+
 
 ## 1.2.0
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -440,7 +440,13 @@ sealed class InternalSuperwallEvent(
 
         override val customParameters: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.customParams().let {
+                    if (superwallEvent is SuperwallEvent.TransactionAbandon) {
+                        it.plus("abandoned_product_id" to (product?.productIdentifier ?: ""))
+                    } else {
+                        it
+                    }
+                }
             }
 
         override val superwallEvent: SuperwallEvent


### PR DESCRIPTION

## Changes in this pull request

- Adds `abandoned_product_id` property to customParameters in case of `TransactionAbandon` events

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)