### PR TITLE
Add multiple paywall URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.2.2
+
+### Enhancements
+
+- Adds support for multiple paywall URLs, in case one CDN provider fails.
+- `ActivityEncapsulatable` now uses a WeakReference instead of a reference
 
 ## 1.2.1
 

--- a/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
@@ -25,7 +25,7 @@ class MockPaywallViewDelegate : PaywallViewCallback {
     ) {
         paywallViewFinished?.invoke(paywall, result, shouldDismiss)
         if (shouldDismiss) {
-            paywall.encapsulatingActivity?.finish()
+            paywall.encapsulatingActivity?.get()?.finish()
         }
     }
 

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/WebviewFallbackClientTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/WebviewFallbackClientTest.kt
@@ -1,0 +1,288 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.vc.webview
+
+import And
+import Given
+import Then
+import When
+import android.webkit.WebView
+import androidx.test.platform.app.InstrumentationRegistry
+import com.superwall.sdk.analytics.SessionEventsManager
+import com.superwall.sdk.dependencies.VariablesFactory
+import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.models.paywall.PaywallWebviewUrl
+import com.superwall.sdk.paywall.vc.web_view.DefaultWebviewClient
+import com.superwall.sdk.paywall.vc.web_view.SWWebView
+import com.superwall.sdk.paywall.vc.web_view.WebviewClientEvent
+import com.superwall.sdk.paywall.vc.web_view.WebviewClientEvent.OnPageFinished
+import com.superwall.sdk.paywall.vc.web_view.WebviewError
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallMessageHandler
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+class WebviewFallbackClientTest {
+    private suspend fun WebView.clientEvents(mainScope: CoroutineScope) =
+        mainScope
+            .async {
+                (webViewClient as DefaultWebviewClient)
+            }.await()
+            .webviewClientEvents
+
+    private suspend fun WebView.waitForEvent(
+        mainScope: CoroutineScope,
+        check: (WebviewClientEvent) -> Boolean,
+    ) = clientEvents(mainScope).first(check)
+
+    private val mainScope = CoroutineScope(Dispatchers.Main)
+
+    private fun createPaywallConfig(vararg configs: PaywallWebviewUrl) =
+        Paywall.stub().let {
+            it.copy(
+                urlConfig =
+                    it.urlConfig!!.copy(
+                        maxAttempts = configs.size,
+                        endpoints = configs.toList(),
+                    ),
+            )
+        }
+
+    @Test
+    fun test_successful_loading() =
+        runTest(timeout = 60.seconds) {
+            val handler =
+                PaywallMessageHandler(
+                    mockk<SessionEventsManager>(),
+                    mockk<VariablesFactory>(),
+                    this,
+                )
+            val paywall =
+                createPaywallConfig(
+                    PaywallWebviewUrl(
+                        url = "https://www.google.com",
+                        score = 10,
+                        timeout = 1000,
+                    ),
+                )
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val webview =
+                mainScope
+                    .async {
+                        SWWebView(context, handler)
+                    }.await()
+            Given("We have list of paywall URLS") {
+                When("we try to load one") {
+                    mainScope.launch {
+                        webview.loadPaywallWithFallbackUrl(paywall)
+                    }
+                    Then("the loading is successful") {
+                        webview
+                            .waitForEvent(mainScope) {
+                                it is OnPageFinished
+                            }.let {
+                                assert(it is OnPageFinished)
+                            }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun test_fail_loading_when_timeout_0() =
+        runTest(timeout = 60.seconds) {
+            val handler =
+                PaywallMessageHandler(
+                    mockk<SessionEventsManager>(),
+                    mockk<VariablesFactory>(),
+                    this,
+                )
+            val paywall =
+                createPaywallConfig(
+                    PaywallWebviewUrl(
+                        url = "https://www.google.com",
+                        score = 10,
+                        timeout = 0,
+                    ),
+                )
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val webview =
+                mainScope
+                    .async {
+                        SWWebView(context, handler)
+                    }.await()
+            Given("We have list of paywall URLS") {
+                When("we try to load one with timeout 0") {
+                    mainScope.launch {
+                        webview.loadPaywallWithFallbackUrl(paywall)
+                    }
+                    Then("the loading fails with an `AllUrlsFailed` error") {
+                        val event =
+                            webview.waitForEvent(mainScope) {
+                                it is WebviewClientEvent.OnError && it.webviewError is WebviewError.AllUrlsFailed
+                            } as WebviewClientEvent.OnError
+                        val error = event.webviewError as WebviewError.AllUrlsFailed
+                        assert(error.urls.containsAll(paywall.urlConfig!!.endpoints.map { it.url }))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun test_failed_loading_falls_back_to_next() =
+        runTest(timeout = 60.seconds) {
+            val handler =
+                PaywallMessageHandler(
+                    mockk<SessionEventsManager>(),
+                    mockk<VariablesFactory>(),
+                    this,
+                )
+            val paywall =
+                createPaywallConfig(
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails.com",
+                        timeout = 100,
+                        score = 100,
+                    ),
+                    PaywallWebviewUrl(
+                        url = "https://www.wikipedia.org",
+                        timeout = 500,
+                        score = 10,
+                    ),
+                )
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val webview =
+                mainScope
+                    .async {
+                        SWWebView(context, handler)
+                    }.await()
+
+            Given("We have list of paywall URLS where the first one fails") {
+                When("we try to load one") {
+                    mainScope.launch {
+                        webview.loadPaywallWithFallbackUrl(paywall)
+                    }
+                    Then("the loading fails and the next one is loaded") {
+                        val events =
+                            webview
+                                .clientEvents(mainScope)
+                                .take(4)
+                                .toList()
+                        assert(events[0] is WebviewClientEvent.OnError)
+                        assert(events.count { it is OnPageFinished && it.url.contains("wiki") } == 1)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun test_failed_loading_until_last_with_score_0() =
+        runTest {
+            val handler =
+                PaywallMessageHandler(
+                    mockk<SessionEventsManager>(),
+                    mockk<VariablesFactory>(),
+                    this,
+                )
+            val paywall =
+                createPaywallConfig(
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails.com",
+                        timeout = 1,
+                        score = 100,
+                    ),
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails-too.com",
+                        timeout = 500,
+                        score = 10,
+                    ),
+                    PaywallWebviewUrl(
+                        url = "https://www.wikipedia.org",
+                        timeout = 500,
+                        score = 0,
+                    ),
+                )
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val webview =
+                mainScope
+                    .async {
+                        SWWebView(context, handler)
+                    }.await()
+            Given("We have list of paywall URLS where the first two fail") {
+                When("we try to load the paywall") {
+                    mainScope.launch {
+                        webview.loadPaywallWithFallbackUrl(paywall)
+                    }
+                    Then("the loading fails until the last one") {
+                        val events =
+                            webview
+                                .clientEvents(mainScope)
+                                .take(7)
+                                .toList()
+                        And("the last one is the one with score 0") {
+                            val last = events.filterIsInstance<OnPageFinished>().last()
+                            assert(last.url.contains("wiki"))
+                        }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun test_failed_loading_all() =
+        runTest {
+            val handler =
+                PaywallMessageHandler(
+                    mockk<SessionEventsManager>(),
+                    mockk<VariablesFactory>(),
+                    this,
+                )
+            val paywall =
+                createPaywallConfig(
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails.com",
+                        timeout = 1,
+                        score = 100,
+                    ),
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails-too.com",
+                        timeout = 500,
+                        score = 10,
+                    ),
+                    PaywallWebviewUrl(
+                        url = "https://www.this-url-doesnt-exist-so-test-fails-third.com",
+                        timeout = 500,
+                        score = 0,
+                    ),
+                )
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val webview =
+                mainScope
+                    .async {
+                        SWWebView(context, handler)
+                    }.await()
+            Given("We have list of paywall URLS where the first two fail") {
+                When("we try to load the paywall") {
+                    mainScope.launch {
+                        webview.loadPaywallWithFallbackUrl(paywall)
+                    }
+                    Then("the loading fails with AllUrlsFailed") {
+                        val event =
+                            webview
+                                .clientEvents(mainScope)
+                                .first {
+                                    it is WebviewClientEvent.OnError && it.webviewError is WebviewError.AllUrlsFailed
+                                } as WebviewClientEvent.OnError
+                        val error = event.webviewError as WebviewError.AllUrlsFailed
+                        assert(error.urls.containsAll(paywall.urlConfig!!.endpoints.map { it.url }))
+                    }
+                }
+            }
+        }
+}

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/messaging/TestPaywallMessageHandlerDelegate.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/messaging/TestPaywallMessageHandlerDelegate.kt
@@ -1,0 +1,44 @@
+package com.superwall.sdk.paywall.presentation.rule_logic.vc.webview.messaging
+
+import android.webkit.WebView
+import com.superwall.sdk.models.events.EventData
+import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.paywall.presentation.PaywallInfo
+import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
+import com.superwall.sdk.paywall.vc.delegate.PaywallLoadingState
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallMessageHandlerDelegate
+import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallWebEvent
+
+class TestPaywallMessageHandlerDelegate(
+    override val request: PresentationRequest? = null,
+    override var paywall: Paywall = Paywall.stub(),
+    override val info: PaywallInfo = Paywall.stub().getInfo(EventData.stub()),
+    override val webView: WebView,
+    override var loadingState: PaywallLoadingState = PaywallLoadingState.Unknown(),
+    override val isActive: Boolean = true,
+    val onEvent: (PaywallWebEvent) -> Unit = {},
+) : PaywallMessageHandlerDelegate {
+    override fun eventDidOccur(paywallWebEvent: PaywallWebEvent) {
+        onEvent(paywallWebEvent)
+    }
+
+    override fun openDeepLink(url: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun presentSafariInApp(url: String) {
+        super.presentSafariInApp(url)
+    }
+
+    override fun presentSafariExternal(url: String) {
+        super.presentSafariExternal(url)
+    }
+
+    override fun presentBrowserInApp(url: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun presentBrowserExternal(url: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/superwall/src/androidTest/java/utils.kt
+++ b/superwall/src/androidTest/java/utils.kt
@@ -1,0 +1,53 @@
+@file:Suppress("ktlint:standard:function-naming")
+
+@DslMarker annotation class TestingDSL
+
+class GivenWhenThenScope(
+    val text: MutableList<String>,
+)
+
+@TestingDSL
+inline fun Given(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    val scope = GivenWhenThenScope(mutableListOf("Given $what"))
+    try {
+        block(scope)
+    } catch (e: Throwable) {
+        e.printStackTrace()
+        println(scope.text.joinToString("\n"))
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun <T> GivenWhenThenScope.When(
+    what: String,
+    block: GivenWhenThenScope.() -> T,
+): T {
+    text.add("\tWhen $what")
+    try {
+        return block(this)
+    } catch (e: Throwable) {
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.Then(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    text.add("\t\tThen $what")
+    block()
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.And(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    text.add("\t\t\tAnd $what")
+    block()
+}

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -7,6 +7,7 @@ import com.superwall.sdk.models.triggers.TriggerResult
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
+import com.superwall.sdk.paywall.vc.web_view.WebviewError
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
 import com.superwall.sdk.store.transactions.RestoreType
@@ -282,7 +283,7 @@ sealed class SuperwallEvent {
     // / When a paywall's website fails to load.
     data class PaywallWebviewLoadFail(
         val paywallInfo: PaywallInfo,
-        val errorMessage: String?,
+        val errorMessage: WebviewError?,
     ) : SuperwallEvent() {
         override val rawName: String
             get() = "paywallWebviewLoad_fail"
@@ -302,6 +303,14 @@ sealed class SuperwallEvent {
     ) : SuperwallEvent() {
         override val rawName: String
             get() = "paywallWebviewLoad_timeout"
+    }
+
+    // When the paywall uses a fallback URL
+    data class PaywallWebviewLoadFallback(
+        val paywallInfo: PaywallInfo,
+    ) : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.PaywallWebviewLoadFallback.rawName
     }
 
     // / When the request to load the paywall's products started.

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -38,6 +38,7 @@ enum class SuperwallEvents(
     PaywallWebviewLoadFail("paywallWebviewLoad_fail"),
     PaywallWebviewLoadComplete("paywallWebviewLoad_complete"),
     PaywallWebviewLoadTimeout("paywallWebviewLoad_timeout"),
+    PaywallWebviewLoadFallback("paywallWebviewLoad_fallback"),
     PaywallProductsLoadStart("paywallProductsLoad_start"),
     PaywallProductsLoadFail("paywallProductsLoad_fail"),
     PaywallProductsLoadComplete("paywallProductsLoad_complete"),

--- a/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
@@ -24,6 +24,7 @@ import com.superwall.sdk.paywall.vc.delegate.PaywallViewCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
 
 @Composable
 fun PaywallComposable(
@@ -55,7 +56,7 @@ fun PaywallComposable(
     LaunchedEffect(Unit) {
         try {
             val newView = Superwall.instance.getPaywall(event, params, paywallOverrides, delegate)
-            newView.encapsulatingActivity = context as? Activity
+            newView.encapsulatingActivity = WeakReference(context as? Activity)
             newView.beforeViewCreated()
             viewState.value = newView
         } catch (e: Throwable) {

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -312,7 +312,6 @@ class DependencyContainer(
                         SWWebView(
                             context = context,
                             messageHandler = messageHandler,
-                            sessionEventsManager = sessionEventsManager,
                         )
 
                     val paywallView =
@@ -327,6 +326,7 @@ class DependencyContainer(
                             storage = storage,
                             webView = webView,
                             eventCallback = Superwall.instance,
+                            useMultipleUrls = configManager.config?.featureFlags?.enableMultiplePaywallUrls ?: false,
                         )
                     webView.delegate = paywallView
                     messageHandler.delegate = paywallView
@@ -511,6 +511,6 @@ class DependencyContainer(
     override suspend fun makeSuperwallOptions(): SuperwallOptions = configManager.options
 
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
-      
+
     override suspend fun provideJavascriptEvaluator(context: Context) = evaluator
 }

--- a/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
@@ -38,6 +38,7 @@ data class Config(
     val featureFlags: FeatureFlags
         get() =
             FeatureFlags(
+                enableMultiplePaywallUrls = rawFeatureFlags.find { it.key == "enable_multiple_paywall_urls" }?.enabled ?: false,
                 enableConfigRefresh = rawFeatureFlags.find { it.key == "enable_config_refresh" }?.enabled ?: false,
                 enableSessionEvents =
                     rawFeatureFlags.find { it.key == "enable_session_events" }?.enabled

--- a/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
@@ -16,6 +16,7 @@ data class FeatureFlags(
     @SerialName("enable_postback") var enablePostback: Boolean,
     @SerialName("enable_userid_seed") var enableUserIdSeed: Boolean,
     @SerialName("disable_verbose_events") var disableVerboseEvents: Boolean,
+    @SerialName("enable_multiple_paywall_urls") var enableMultiplePaywallUrls: Boolean,
 )
 
 fun List<RawFeatureFlag>.value(

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -87,6 +87,8 @@ data class Paywall(
     var experiment: Experiment? = null,
     @kotlinx.serialization.Transient()
     var closeReason: PaywallCloseReason = PaywallCloseReason.None,
+    @SerialName("url_config")
+    val urlConfig: PaywallWebviewUrl.Config? = null,
     /**
      Surveys to potentially show when an action happens in the paywall.
      */
@@ -245,6 +247,13 @@ data class Paywall(
                 featureGating = FeatureGatingBehavior.NonGated,
                 localNotifications = arrayListOf(),
                 presentationDelay = 300,
+                urlConfig =
+                    PaywallWebviewUrl.Config(
+                        3,
+                        listOf(
+                            PaywallWebviewUrl("https://google.com", 1000L, 1),
+                        ),
+                    ),
             )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallWebviewUrl.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallWebviewUrl.kt
@@ -1,0 +1,22 @@
+package com.superwall.sdk.models.paywall
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PaywallWebviewUrl(
+    @SerialName("url")
+    val url: String,
+    @SerialName("timeout_ms")
+    val timeout: Long,
+    @SerialName("percentage")
+    val score: Int,
+) {
+    @Serializable
+    data class Config(
+        @SerialName("max_attempts")
+        val maxAttempts: Int,
+        @SerialName("endpoints")
+        val endpoints: List<PaywallWebviewUrl>,
+    )
+}

--- a/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
@@ -31,6 +31,10 @@ internal sealed class Capability(
                 SuperwallEvents.PaywallClose,
             ).map { it.rawName }
     }
+
+    @Serializable
+    @SerialName("multiple_paywall_urls")
+    object MultiplePaywallUrls : Capability("multiple_paywall_urls")
 }
 
 internal fun List<Capability>.toJson(json: Json): JsonElement = json.encodeToJsonElement(this)

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -417,7 +417,8 @@ class DeviceHelper(
                 )
                 null
             }
-        val capabilities: List<Capability> = listOf(Capability.PaywallEventReceiver())
+        val capabilities: List<Capability> = listOf(Capability.PaywallEventReceiver(), Capability.MultiplePaywallUrls)
+
         val deviceTemplate =
             DeviceTemplate(
                 publicApiKey = storage.apiKey,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
 import java.net.MalformedURLException
 import java.net.URL
 import java.util.Date
@@ -72,6 +73,7 @@ class PaywallView(
     override val webView: SWWebView,
     private val loadingView: LoadingView = LoadingView(context),
     private val cache: PaywallViewCache?,
+    private val useMultipleUrls: Boolean,
 ) : FrameLayout(context),
     PaywallMessageHandlerDelegate,
     SWWebViewDelegate,
@@ -97,7 +99,7 @@ class PaywallView(
     var paywallStatePublisher: MutableSharedFlow<PaywallState>? = null
 
     // The full screen activity instance if this view controller has been presented in one.
-    override var encapsulatingActivity: Activity? = null
+    override var encapsulatingActivity: WeakReference<Activity>? = null
 
     // / Stores the ``PaywallResult`` on dismiss of paywall.
     private var paywallResult: PaywallResult? = null
@@ -181,7 +183,7 @@ class PaywallView(
     //endregion
 
     //region Initialization
-    val mainScope = CoroutineScope(Dispatchers.Main)
+    private val mainScope = CoroutineScope(Dispatchers.Main)
 
     init {
         // Add the webView
@@ -402,11 +404,21 @@ class PaywallView(
             }
         }
 
+        val dismiss = {
+            CoroutineScope(Dispatchers.IO).launch {
+                dismissView()
+            }
+        }
+
         SurveyManager.presentSurveyIfAvailable(
             paywall.surveys,
             paywallResult = result,
             paywallCloseReason = closeReason,
-            activity = encapsulatingActivity,
+            activity =
+                encapsulatingActivity?.get() ?: run {
+                    dismiss()
+                    return
+                },
             paywallView = this,
             loadingState = loadingState,
             isDebuggerLaunched = request?.flags?.isDebuggerLaunched == true,
@@ -415,9 +427,7 @@ class PaywallView(
             factory = factory,
         ) { result ->
             this.surveyPresentationResult = result
-            CoroutineScope(Dispatchers.IO).launch {
-                dismissView()
-            }
+            dismiss()
         }
     }
 
@@ -525,7 +535,7 @@ class PaywallView(
         // TODO: SW-2162 Implement animation support
         // https://linear.app/superwall/issue/SW-2162/%5Bandroid%5D-%5Bv1%5D-get-animated-presentation-working
 
-        encapsulatingActivity?.finish()
+        encapsulatingActivity?.get()?.finish()
     }
 
     private fun showLoadingView() {
@@ -589,7 +599,7 @@ class PaywallView(
         action: (() -> Unit)? = null,
         onClose: (() -> Unit)? = null,
     ) {
-        val activity = encapsulatingActivity ?: return
+        val activity = encapsulatingActivity?.get() ?: return
 
         val alertController =
             AlertControllerFactory.make(
@@ -697,7 +707,7 @@ class PaywallView(
                 paywall.webviewLoadingInfo.startAt = Date()
             }
 
-            CoroutineScope(Dispatchers.IO).launch {
+            launch {
                 val trackedEvent =
                     InternalSuperwallEvent.PaywallWebviewLoad(
                         state = InternalSuperwallEvent.PaywallWebviewLoad.State.Start(),
@@ -706,13 +716,17 @@ class PaywallView(
                 Superwall.instance.track(trackedEvent)
             }
 
-            launch(Dispatchers.Main) {
+            mainScope.launch {
                 if (paywall.onDeviceCache is OnDeviceCaching.Enabled) {
                     webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
                 } else {
                     webView.settings.cacheMode = WebSettings.LOAD_DEFAULT
                 }
-                webView.loadUrl(url.toString())
+                if (useMultipleUrls) {
+                    webView.loadPaywallWithFallbackUrl(paywall)
+                } else {
+                    webView.loadUrl(url.toString())
+                }
             }
 
             loadingState = PaywallLoadingState.LoadingURL()
@@ -813,5 +827,5 @@ class PaywallView(
 }
 
 interface ActivityEncapsulatable {
-    var encapsulatingActivity: Activity?
+    var encapsulatingActivity: WeakReference<Activity>?
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -34,6 +34,7 @@ import com.superwall.sdk.store.transactions.notifications.NotificationScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -135,7 +136,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             }
 
         (view.parent as? ViewGroup)?.removeView(view)
-        view.encapsulatingActivity = this
+        view.encapsulatingActivity = WeakReference(this)
 
         setContentView(view)
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebviewClient.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebviewClient.kt
@@ -1,0 +1,79 @@
+package com.superwall.sdk.paywall.vc.web_view
+
+import android.graphics.Bitmap
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+internal open class DefaultWebviewClient(
+    private val ioScope: CoroutineScope,
+) : WebViewClient() {
+    val webviewClientEvents: MutableSharedFlow<WebviewClientEvent> =
+        MutableSharedFlow(extraBufferCapacity = 4)
+
+    override fun shouldOverrideUrlLoading(
+        view: WebView?,
+        request: WebResourceRequest?,
+    ): Boolean = true
+
+    override fun onPageStarted(
+        view: WebView?,
+        url: String?,
+        favicon: Bitmap?,
+    ) {
+        super.onPageStarted(view, url, favicon)
+    }
+
+    override fun onPageFinished(
+        view: WebView,
+        url: String,
+    ) {
+        ioScope.launch {
+            webviewClientEvents.emit(WebviewClientEvent.OnPageFinished(url))
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        errorResponse: WebResourceResponse?,
+    ) {
+        ioScope.launch {
+            webviewClientEvents.emit(
+                WebviewClientEvent.OnError(
+                    WebviewError.NetworkError(
+                        errorResponse?.statusCode ?: -1,
+                        errorResponse?.let {
+                            val body = it.data?.bufferedReader()?.use { it.readText() } ?: "Unknown"
+                            "Error: ${errorResponse.reasonPhrase} -\n $body"
+                        } ?: "Unknown error",
+                        request?.url?.toString() ?: "",
+                    ),
+                ),
+            )
+        }
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError,
+    ) {
+        ioScope.launch {
+            webviewClientEvents.emit(
+                WebviewClientEvent.OnError(
+                    WebviewError.NetworkError(
+                        error.errorCode,
+                        error.description.toString(),
+                        request?.url?.toString() ?: "",
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewClientEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewClientEvent.kt
@@ -1,0 +1,39 @@
+package com.superwall.sdk.paywall.vc.web_view
+
+sealed class WebviewClientEvent {
+    data class OnPageFinished(
+        val url: String,
+    ) : WebviewClientEvent()
+
+    data class OnError(
+        val webviewError: WebviewError,
+    ) : WebviewClientEvent()
+
+    data object LoadingFallback : WebviewClientEvent()
+}
+
+sealed class WebviewError {
+    data class NetworkError(
+        val code: Int,
+        val description: String,
+        val url: String,
+    ) : WebviewError() {
+        override fun toString(): String = "The network failed with error code: $code - $description - $url ."
+    }
+
+    data class MaxAttemptsReached(
+        val urls: List<String>,
+    ) : WebviewError() {
+        override fun toString(): String = "The webview has attempted to load too many times."
+    }
+
+    data object NoUrls : WebviewError() {
+        override fun toString() = "There were no paywall URLs provided."
+    }
+
+    data class AllUrlsFailed(
+        val urls: List<String>,
+    ) : WebviewError() {
+        override fun toString(): String = "All paywall URLs have failed to load."
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewFallbackClient.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewFallbackClient.kt
@@ -1,0 +1,199 @@
+package com.superwall.sdk.paywall.vc.web_view
+
+import android.graphics.Bitmap
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import com.superwall.sdk.models.paywall.PaywallWebviewUrl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/*
+* An implementation of a FallbackHandler and a WebViewClient that will attempt to load a PaywallWebviewUrl from
+* a list of URLs with a weighted probability. If the loading fails, it will try to load another URL from the list.
+* */
+internal class WebviewFallbackClient(
+    private val config: PaywallWebviewUrl.Config,
+    private val ioScope: CoroutineScope,
+    private val mainScope: CoroutineScope,
+    private val loadUrl: (PaywallWebviewUrl) -> Unit,
+) : DefaultWebviewClient(ioScope) {
+    private var failureCount = 0
+
+    private val urls = config.endpoints
+
+    private val untriedUrls = urls.toMutableSet()
+
+    private sealed interface UrlState {
+        object None : UrlState
+
+        object Loading : UrlState
+
+        object PageStarted : UrlState
+
+        object PageError : UrlState
+
+        object Timeout : UrlState
+    }
+
+    private val timeoutFlow = MutableStateFlow<UrlState>(UrlState.None)
+
+    /*
+     * When page starts Loading, we wait for N miliseconds until we consider it timed out.
+     * If it is timedOut, we update the timeoutFlow so the client knows it can start loading
+     * next fallback URL
+     * */
+    override fun onPageStarted(
+        view: WebView?,
+        url: String?,
+        favicon: Bitmap?,
+    ) {
+        super.onPageStarted(view, url, favicon)
+        val timeoutForUrl =
+            urls.find { url?.contains(it.url) ?: false }?.timeout
+                ?: error("No such URL($url in list of - ${urls.joinToString()} ")
+        ioScope.launch {
+            timeoutFlow.update { UrlState.Loading }
+            try {
+                withTimeout(timeoutForUrl) {
+                    timeoutFlow.first { it is UrlState.PageStarted || it is UrlState.PageError }
+                }
+            } catch (e: TimeoutCancellationException) {
+                timeoutFlow.update { UrlState.Timeout }
+            }
+        }
+    }
+
+    /*
+     * Indicates the page has started loading resources, meaning we won't need to
+     * fallback to another URL so we can stop the timeout handler.
+     * */
+
+    override fun onLoadResource(
+        view: WebView?,
+        url: String?,
+    ) {
+        super.onLoadResource(view, url)
+        ioScope.launch {
+            if (timeoutFlow.value == UrlState.Loading) {
+                timeoutFlow.emit(UrlState.PageStarted)
+            }
+        }
+    }
+
+    internal fun nextUrl(): PaywallWebviewUrl {
+        if (failureCount <= config.maxAttempts) {
+            failureCount += 1
+            return if (untriedUrls.all { it.score == 0 }) {
+                nextWeightedUrl(untriedUrls)
+            } else {
+                nextWeightedUrl(untriedUrls.filter { it.score != 0 })
+            }
+        } else {
+            throw IllegalArgumentException("Max attempts reached")
+        }
+    }
+
+    override fun onPageFinished(
+        view: WebView,
+        url: String,
+    ) {
+        super.onPageFinished(view, url)
+        failureCount = 0
+    }
+
+    private tailrec fun evaluateNext(
+        chosenNumber: Int,
+        untriedUrls: Collection<PaywallWebviewUrl>,
+        accumulatedScore: Int = 0,
+    ): PaywallWebviewUrl {
+        val toTry =
+            untriedUrls.firstOrNull() ?: throw NoSuchElementException("No more URLs to evaluate")
+        val accScore = accumulatedScore + toTry.score
+        return if (chosenNumber < accScore) {
+            toTry
+        } else {
+            evaluateNext(chosenNumber, untriedUrls.drop(1), accScore)
+        }
+    }
+
+    private fun nextWeightedUrl(fromUrls: Collection<PaywallWebviewUrl>): PaywallWebviewUrl {
+        val totalScore = fromUrls.sumOf { it.score }
+
+        if (totalScore == 0) {
+            val url = untriedUrls.random()
+            untriedUrls.remove(url)
+            return url
+        }
+
+        val random = (0 until totalScore).random()
+        val next = evaluateNext(random, untriedUrls, 0)
+        untriedUrls.remove(next)
+        return next
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        errorResponse: WebResourceResponse?,
+    ) {
+        super.onReceivedHttpError(view, request, errorResponse)
+        loadWithFallback()
+    }
+
+    internal fun loadWithFallback() {
+        // If we have no URLs to try, we emit an error
+        if (urls.isEmpty()) {
+            ioScope.launch {
+                webviewClientEvents.emit(WebviewClientEvent.OnError(WebviewError.NoUrls))
+            }
+            return
+        }
+
+        // We try to get the next URL
+        val url =
+            try {
+                nextUrl()
+            } catch (e: NoSuchElementException) {
+                // If there is no more URLS, we let the client know
+                ioScope.launch {
+                    webviewClientEvents.emit(WebviewClientEvent.OnError(WebviewError.AllUrlsFailed(urls.map { it.url })))
+                }
+                return
+            }
+        if (failureCount > 0) {
+            ioScope.launch {
+                webviewClientEvents.emit(WebviewClientEvent.LoadingFallback)
+            }
+        }
+
+        mainScope.launch {
+            loadUrl(url)
+            ioScope.launch {
+                val nextEvent =
+                    timeoutFlow.first { it is UrlState.PageStarted || it is UrlState.Timeout || it is UrlState.PageError }
+                if (nextEvent is UrlState.Timeout) {
+                    loadWithFallback()
+                } else {
+                    timeoutFlow.update { UrlState.None }
+                }
+            }
+        }
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError,
+    ) {
+        timeoutFlow.update { UrlState.PageError }
+        super.onReceivedError(view, request, error)
+        loadWithFallback()
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/models/config/ConfigTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/models/config/ConfigTest.kt
@@ -455,7 +455,8 @@ class ConfigTest {
   "disable_preload": {
     "all": false,
     "triggers": []
-  }
+  },
+  "build_id": "test"
 }
             """.trimIndent()
 


### PR DESCRIPTION
## Changes in this pull request

- Adds multiple paywall URLS loading capabilities to use as fallback when one CDN is not reachable
- Creates a `WebviewFallbackClient` that counts failures and loads different URL's according to weight
- Adds `WebviewClientEvent` to track occuring events in the webview without restorting to callbacks
- Adds `DefaultWebviewClient` to use for default behaviour when multiple URLS are not allowed
-  Changes activity reference to `WeakReference` for `encapsulatedActivity` to avoid leaks
-  Adds a `Given/When/Then testing` DSL to make tests easier to understand and track

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)