### PR TITLE
Add error tracking events for crash traces

### DIFF
--- a/superwall/src/androidTest/java/com/superwall/sdk/utilities/ErrorTrackingTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/utilities/ErrorTrackingTest.kt
@@ -1,0 +1,59 @@
+package com.superwall.sdk.utilities
+
+import com.superwall.sdk.storage.ErrorLog
+import com.superwall.sdk.storage.Storage
+import io.mockk.Runs
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ErrorTrackingTest {
+    @Test
+    fun should_save_error_when_occured() =
+        runTest {
+            val storage =
+                mockk<Storage> {
+                    every { save(any(), ErrorLog) } just Runs
+                    every { get(ErrorLog) } returns null
+                }
+            val errorTracker: ErrorTracking =
+                ErrorTracker(this, storage, {
+                    assert(false)
+                })
+
+            errorTracker.trackError(Exception("Test Error"))
+            coVerify { storage.save(any(), ErrorLog) }
+        }
+
+    @Test
+    fun should_track_error_when_invoked() =
+        runTest {
+            val error = ErrorTracking.ErrorOccurence("Test Error", "Test Stacktrace", System.currentTimeMillis())
+            val storage =
+                mockk<Storage> {
+                    every { save(any(), ErrorLog) } just Runs
+                    every { get(ErrorLog) } returns error
+                    every { remove(ErrorLog) } just Runs
+                }
+
+            var tracked = MutableStateFlow(false)
+            launch {
+                // Will timeout if not tracked
+                tracked.filter { it }.first()
+            }
+            val errorTracker: ErrorTracking =
+                ErrorTracker(this, storage, {
+                    tracked.update { true }
+                })
+
+            coVerify { storage.get(ErrorLog) }
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -749,4 +749,16 @@ sealed class InternalSuperwallEvent(
         override val customParameters: Map<String, Any>
             get() = paywallInfo.customParams()
     }
+
+    data class ErrorThrown(
+        val error: Exception,
+    ) : InternalSuperwallEvent(SuperwallEvent.ErrorThrown(error)) {
+        override val customParameters: Map<String, Any> = emptyMap()
+
+        override suspend fun getSuperwallParameters() =
+            mapOf(
+                "error_message" to (error.message ?: "No message"),
+                "error_stack_trace" to (error.stackTraceToString() ?: "No stack trace"),
+            )
+    }
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -750,15 +750,24 @@ sealed class InternalSuperwallEvent(
             get() = paywallInfo.customParams()
     }
 
-    data class ErrorThrown(
-        val error: Exception,
-    ) : InternalSuperwallEvent(SuperwallEvent.ErrorThrown(error)) {
+    internal data class ErrorThrown(
+        val message: String,
+        val stacktrace: String,
+        val occuredAt: Long,
+    ) : InternalSuperwallEvent(SuperwallEvent.ErrorThrown) {
+        constructor(error: Throwable) : this(
+            error.message ?: "",
+            error.stackTraceToString(),
+            System.currentTimeMillis(),
+        )
+
         override val customParameters: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters() =
             mapOf(
-                "error_message" to (error.message ?: "No message"),
-                "error_stack_trace" to (error.stackTraceToString() ?: "No stack trace"),
+                "error_message" to message,
+                "error_stack_trace" to stacktrace,
+                "occured_at" to occuredAt,
             )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -370,6 +370,13 @@ sealed class SuperwallEvent {
             get() = "reset"
     }
 
+    data class ErrorThrown(
+        val e: Exception,
+    ) : SuperwallEvent() {
+        override val rawName: String
+            get() = "error_thrown"
+    }
+
     open val rawName: String
         get() = this.toString()
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -370,9 +370,7 @@ sealed class SuperwallEvent {
             get() = "reset"
     }
 
-    data class ErrorThrown(
-        val e: Exception,
-    ) : SuperwallEvent() {
+    object ErrorThrown : SuperwallEvent() {
         override val rawName: String
             get() = "error_thrown"
     }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -511,6 +511,6 @@ class DependencyContainer(
     override suspend fun makeSuperwallOptions(): SuperwallOptions = configManager.options
 
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
-      
+
     override suspend fun provideJavascriptEvaluator(context: Context) = evaluator
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -61,6 +61,7 @@ import com.superwall.sdk.store.abstractions.transactions.GoogleBillingPurchaseTr
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.transactions.TransactionManager
 import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.ErrorTracker
 import com.superwall.sdk.utilities.dateFormat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -126,6 +127,8 @@ class DependencyContainer(
         )
     }
 
+    internal val errorTracker: ErrorTracker
+
     init {
         // TODO: Add delegate adapter
 
@@ -163,7 +166,7 @@ class DependencyContainer(
         delegateAdapter = SuperwallDelegateAdapter()
         storage = Storage(context = context, factory = this)
         network = Network(factory = this)
-
+        errorTracker = ErrorTracker(scope = ioScope, cache = storage)
         paywallRequestManager =
             PaywallRequestManager(
                 storeKitManager = storeKitManager,

--- a/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
@@ -16,6 +16,7 @@ import com.superwall.sdk.storage.DidTrackFirstSeen
 import com.superwall.sdk.storage.Seed
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.storage.UserAttributes
+import com.superwall.sdk.utilities.withErrorTrackingAsync
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -130,7 +131,7 @@ class IdentityManager(
         options: IdentityOptions? = null,
     ) {
         scope.launch {
-            try {
+            withErrorTrackingAsync {
                 IdentityLogic.sanitize(userId)?.let { sanitizedUserId ->
                     if (_appUserId == sanitizedUserId || sanitizedUserId == "") {
                         if (sanitizedUserId == "") {
@@ -140,7 +141,7 @@ class IdentityManager(
                                 message = "The provided userId was empty.",
                             )
                         }
-                        return@launch
+                        return@withErrorTrackingAsync
                     }
 
                     identityFlow.emit(false)
@@ -186,9 +187,6 @@ class IdentityManager(
                         didSetIdentity()
                     }
                 }
-            } catch (e: Exception) {
-                Superwall.instance.track(InternalSuperwallEvent.ErrorThrown(e))
-                throw e
             }
         }
     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
@@ -31,6 +31,8 @@ suspend fun Superwall.logErrors(
                 track(trackedEvent)
             }
         }
+    } else {
+        track(InternalSuperwallEvent.ErrorThrown(Exception(error)))
     }
 
     Logger.debug(

--- a/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
@@ -75,7 +75,6 @@ class Cache(
 
     fun <T : Any> delete(storable: Storable<T>) {
         memCache.remove(storable.key)
-
         launch {
             val file = File(storable.path(context = context))
             if (file.exists()) {

--- a/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
@@ -7,6 +7,7 @@ import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.models.triggers.ExperimentID
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.ErrorTracking
 import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
@@ -231,6 +232,14 @@ object DisableVerboseEvents : Storable<Boolean> {
         get() = Boolean.serializer()
 }
 
+internal object ErrorLog : Storable<ErrorTracking.ErrorOccurence> {
+    override val key: String
+        get() = "store.errorLog"
+    override val directory: SearchPathDirectory
+        get() = SearchPathDirectory.CACHE
+    override val serializer: KSerializer<ErrorTracking.ErrorOccurence>
+        get() = ErrorTracking.ErrorOccurence.serializer()
+}
 //endregion
 
 // region Serializers

--- a/superwall/src/main/java/com/superwall/sdk/storage/Storage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/Storage.kt
@@ -199,6 +199,8 @@ open class Storage(
 
     //region Cache Reading & Writing
 
+    fun <T : Any> remove(storable: Storable<T>) = cache.delete(storable)
+
     fun <T> get(storable: Storable<T>): T? = cache.read(storable)
 
     fun <T : Any> save(

--- a/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
@@ -1,0 +1,101 @@
+package com.superwall.sdk.utilities
+
+import com.superwall.sdk.Superwall
+import com.superwall.sdk.analytics.internal.track
+import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.storage.ErrorLog
+import com.superwall.sdk.storage.Storage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+internal interface ErrorTracking {
+    fun trackError(throwable: Throwable)
+
+    @Serializable
+    data class ErrorOccurence(
+        @SerialName("message")
+        val message: String,
+        @SerialName("stacktrace")
+        val stacktrace: String,
+        @SerialName("timestamp")
+        val timestamp: Long,
+    )
+}
+
+/**
+ * Used to track errors that occur in the SDK.
+ * When an error occurs, it is stored in the cache and sent to the server when the SDK is initialized.
+ * This ensures the error is logged even with the crash occurring. We only save a single error
+ * in cache at a time, to ensure only the crashing error is logged. This also helps us avoid logging the
+ * same error multiple times without relying on hashcodes or unique identifier.
+ **/
+internal class ErrorTracker(
+    scope: CoroutineScope,
+    private val cache: Storage,
+    private val track: suspend (InternalSuperwallEvent.ErrorThrown) -> Unit = {
+        Superwall.instance.track(
+            it,
+        )
+    },
+) : ErrorTracking {
+    init {
+        val exists = cache.get(ErrorLog)
+        if (exists != null) {
+            scope.launch {
+                track(
+                    InternalSuperwallEvent.ErrorThrown(
+                        exists.message,
+                        exists.stacktrace,
+                        exists.timestamp,
+                    ),
+                )
+                cache.remove(ErrorLog)
+            }
+        }
+    }
+
+    override fun trackError(throwable: Throwable) {
+        val errorOccurence =
+            ErrorTracking.ErrorOccurence(
+                message = throwable.message ?: "",
+                stacktrace = throwable.stackTraceToString(),
+                timestamp = System.currentTimeMillis(),
+            )
+        cache.save(errorOccurence, ErrorLog)
+    }
+}
+
+// Utility methods and closures for error tracking
+
+internal fun Superwall.trackError(e: Throwable) {
+    dependencyContainer.errorTracker.trackError(e)
+}
+
+internal fun withErrorTracking(block: () -> Unit) {
+    try {
+        block()
+    } catch (e: Throwable) {
+        Superwall.instance.trackError(e)
+        throw e
+    }
+}
+
+internal suspend fun <T> withErrorTrackingAsync(block: suspend () -> T): T {
+    try {
+        return block()
+    } catch (e: Throwable) {
+        Superwall.instance.trackError(e)
+        throw e
+    }
+}
+
+internal fun <T> withErrorTracking(block: () -> T): T {
+    try {
+        return block()
+    } catch (e: Throwable) {
+        Superwall.instance.trackError(e)
+        throw e
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

- Adds a new trackable event `error_thrown` that contains an `error_message` and `error_stacktrace` 
- Wraps publicly exposed SDK methods in a `withErrorTracking` block that logs the error before throwing
- The logged error is saved and will be published to events on next app start

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)