### PR TITLE
Add build cache key and tracking event cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 - SW-2900: Adds Superwall.instance.localeIdentifier as a convenience variable that you can use to dynamically update the locale used for evaluating rules and getting localized paywalls.
 - SW-2919: Adds a `custom_placement` event that you can attach to any element in the paywall with a dictionary of parameters. When the element is tapped, the event will be tracked. The name of the placement can be used to trigger a paywall and its params used in audience filters.
 - Adds support for bottom sheet presentation style
+- Adds `build_id` and `cache_key` to `PaywallInfo`.
 
 ## 1.2.1
 

--- a/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
@@ -1,0 +1,57 @@
+package com.superwall.sdk.analytics.internal
+
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import com.superwall.sdk.Superwall
+import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.identity.IdentityInfo
+import com.superwall.sdk.network.Network
+import com.superwall.sdk.network.device.DeviceHelper
+import com.superwall.sdk.storage.LastPaywallView
+import com.superwall.sdk.storage.Storage
+import com.superwall.sdk.storage.TotalPaywallViews
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class TrackingLogicTest {
+    val store =
+        mockk<Storage> {
+            every { apiKey } returns "pk_test_1234"
+            every { didTrackFirstSession } returns true
+            every { didTrackFirstSeen } returns true
+            every { get(LastPaywallView) } returns null
+            every { get(TotalPaywallViews) } returns 0
+        }
+    val network = mockk<Network>()
+
+    @Test
+    fun should_clean_up_attributes() =
+        runTest {
+            val ctx = InstrumentationRegistry.getInstrumentation().context
+            Superwall.configure(ctx, "pk_test_1234", null, null, null, null)
+            val deviceHelper =
+                spyk(
+                    DeviceHelper(
+                        ctx,
+                        storage = store,
+                        network = network,
+                        factory =
+                            object : DeviceHelper.Factory {
+                                override suspend fun makeIdentityInfo(): IdentityInfo = IdentityInfo("aliasId", "appUserId")
+
+                                override fun makeLocaleIdentifier(): String? = "en-US"
+                            },
+                    ),
+                ) {
+                    every { appVersion } returns "123"
+                }
+            val attributes = deviceHelper.getTemplateDevice()
+            val event = InternalSuperwallEvent.DeviceAttributes(HashMap(attributes))
+            val res = TrackingLogic.processParameters(event, "appSessionId")
+            Log.e("res", res.toString())
+            assert(res.eventParams.isEmpty())
+        }
+}

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -20,6 +20,8 @@ import com.superwall.sdk.misc.awaitFirstValidConfig
 import com.superwall.sdk.models.assignment.AssignmentPostback
 import com.superwall.sdk.models.assignment.ConfirmableAssignment
 import com.superwall.sdk.models.config.Config
+import com.superwall.sdk.models.paywall.CacheKey
+import com.superwall.sdk.models.paywall.PaywallIdentifier
 import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.models.triggers.ExperimentID
 import com.superwall.sdk.models.triggers.Trigger
@@ -385,14 +387,14 @@ open class ConfigManager(
         val newPaywalls = newConfig.paywalls
 
         val presentedPaywallId = paywallManager.currentView?.paywall?.identifier
-        val oldPaywallCacheIds =
+        val oldPaywallCacheIds: Map<PaywallIdentifier, CacheKey> =
             oldPaywalls
                 .map { it.identifier to it.cacheKey }
                 .toMap()
-        val newPaywallCacheIds = newPaywalls.map { it.identifier to it.cacheKey }.toMap()
+        val newPaywallCacheIds: Map<PaywallIdentifier, CacheKey> = newPaywalls.map { it.identifier to it.cacheKey }.toMap()
 
-        val removedIds =
-            oldPaywallCacheIds.values - newPaywallCacheIds.values.toSet()
+        val removedIds: Set<PaywallIdentifier> =
+            (oldPaywallCacheIds.keys - newPaywallCacheIds.keys).toSet()
 
         val changedIds =
             removedIds +

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -355,7 +355,7 @@ class DependencyContainer(
         return view
     }
 
-    override fun makeCache(): PaywallViewCache = PaywallViewCache(context, Superwall.instance.viewStore(), activityProvider!!)
+    override fun makeCache(): PaywallViewCache = PaywallViewCache(context, Superwall.instance.viewStore(), activityProvider!!, deviceHelper)
 
     override fun makeDeviceInfo(): DeviceInfo =
         DeviceInfo(

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -97,6 +97,12 @@ data class Paywall(
     var closeReason: PaywallCloseReason = PaywallCloseReason.None,
     @SerialName("url_config")
     val urlConfig: PaywallWebviewUrl.Config? = null,
+    @Serializable
+    @SerialName("cache_key")
+    val cacheKey: String,
+    @Serializable
+    @SerialName("build_id")
+    val buildId: String,
     /**
      Surveys to potentially show when an action happens in the paywall.
      */
@@ -199,6 +205,8 @@ data class Paywall(
             computedPropertyRequests = computedPropertyRequests,
             surveys = surveys,
             presentation = presentation,
+            cacheKey = cacheKey,
+            buildId = buildId,
         )
 
     companion object {
@@ -262,6 +270,8 @@ data class Paywall(
                             PaywallWebviewUrl("https://google.com", 1000L, 1),
                         ),
                     ),
+                cacheKey = "123",
+                buildId = "test",
             )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -34,7 +34,7 @@ data class Paywalls(
 data class Paywall(
     @SerialName("id")
     val databaseId: String,
-    var identifier: String,
+    var identifier: PaywallIdentifier,
     val name: String,
     val url:
         @Serializable(with = URLSerializer::class)
@@ -99,7 +99,7 @@ data class Paywall(
     val urlConfig: PaywallWebviewUrl.Config? = null,
     @Serializable
     @SerialName("cache_key")
-    val cacheKey: String,
+    val cacheKey: CacheKey,
     @Serializable
     @SerialName("build_id")
     val buildId: String,

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/typealiases.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/typealiases.kt
@@ -1,0 +1,4 @@
+package com.superwall.sdk.models.paywall
+
+typealias CacheKey = String
+typealias PaywallIdentifier = String

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
@@ -117,7 +117,7 @@ class PaywallManager(
                 cache = cache,
                 delegate = delegate,
             )
-        cache.save(paywallView, cacheKey)
+        cache.save(paywallView, paywall.identifier)
         if (isForPresentation) {
             // Only preload if it's actually gonna present the view.
             // Not if we're just checking its result

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
@@ -3,6 +3,7 @@ package com.superwall.sdk.paywall.manager
 import com.superwall.sdk.dependencies.CacheFactory
 import com.superwall.sdk.dependencies.DeviceHelperFactory
 import com.superwall.sdk.dependencies.ViewFactory
+import com.superwall.sdk.models.paywall.PaywallIdentifier
 import com.superwall.sdk.paywall.request.PaywallRequest
 import com.superwall.sdk.paywall.request.PaywallRequestManager
 import com.superwall.sdk.paywall.vc.PaywallView
@@ -52,8 +53,8 @@ class PaywallManager(
         removePaywallView(forKey)
     }
 
-    fun removePaywallView(forKey: String) {
-        cache.removePaywallView(forKey)
+    fun removePaywallView(identifier: PaywallIdentifier) {
+        cache.removePaywallView(identifier)
     }
 
     fun resetCache() {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
@@ -2,6 +2,7 @@ package com.superwall.sdk.paywall.manager
 
 import android.content.Context
 import com.superwall.sdk.misc.ActivityProvider
+import com.superwall.sdk.models.paywall.PaywallIdentifier
 import com.superwall.sdk.network.device.DeviceHelper
 import com.superwall.sdk.paywall.vc.LoadingView
 import com.superwall.sdk.paywall.vc.PaywallView
@@ -81,11 +82,11 @@ class PaywallViewCache(
 
     fun getPaywallView(key: String): PaywallView? = runBlocking(singleThreadContext) { store.retrieveView(key) as PaywallView? }
 
-    fun removePaywallView(key: String) {
+    fun removePaywallView(identifier: PaywallIdentifier) {
         CoroutineScope(singleThreadContext).launch {
             store.removeView(
                 PaywallCacheLogic.key(
-                    key,
+                    identifier,
                     locale = deviceHelper.locale,
                 ),
             )

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
@@ -55,9 +55,17 @@ class PaywallViewCache(
 
     fun save(
         paywallView: PaywallView,
-        key: String,
+        identifier: PaywallIdentifier,
     ) {
-        CoroutineScope(singleThreadContext).launch { store.storeView(key, paywallView) }
+        CoroutineScope(singleThreadContext).launch {
+            store.storeView(
+                PaywallCacheLogic.key(
+                    identifier,
+                    locale = deviceHelper.locale,
+                ),
+                paywallView,
+            )
+        }
     }
 
     fun acquireLoadingView(): LoadingView {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
@@ -2,6 +2,7 @@ package com.superwall.sdk.paywall.manager
 
 import android.content.Context
 import com.superwall.sdk.misc.ActivityProvider
+import com.superwall.sdk.network.device.DeviceHelper
 import com.superwall.sdk.paywall.vc.LoadingView
 import com.superwall.sdk.paywall.vc.PaywallView
 import com.superwall.sdk.paywall.vc.ShimmerView
@@ -15,6 +16,7 @@ class PaywallViewCache(
     private val appCtx: Context,
     private val store: ViewStorage,
     private val activityProvider: ActivityProvider,
+    private val deviceHelper: DeviceHelper,
 ) {
     private val ctx: Context = activityProvider.getCurrentActivity() ?: appCtx
     private var _activePaywallVcKey: String? = null
@@ -80,7 +82,14 @@ class PaywallViewCache(
     fun getPaywallView(key: String): PaywallView? = runBlocking(singleThreadContext) { store.retrieveView(key) as PaywallView? }
 
     fun removePaywallView(key: String) {
-        CoroutineScope(singleThreadContext).launch { store.removeView(key) }
+        CoroutineScope(singleThreadContext).launch {
+            store.removeView(
+                PaywallCacheLogic.key(
+                    key,
+                    locale = deviceHelper.locale,
+                ),
+            )
+        }
     }
 
     fun removeAll() {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -62,6 +62,8 @@ data class PaywallInfo(
     val computedPropertyRequests: List<ComputedPropertyRequest>,
     val surveys: List<Survey>,
     val presentation: PaywallPresentationInfo,
+    val buildId: String,
+    val cacheKey: String,
 ) {
     constructor(
         databaseId: String,
@@ -91,6 +93,8 @@ data class PaywallInfo(
         closeReason: PaywallCloseReason,
         surveys: List<Survey>,
         presentation: PaywallPresentationInfo,
+        buildId: String,
+        cacheKey: String,
     ) : this(
         databaseId = databaseId,
         identifier = identifier,
@@ -140,6 +144,8 @@ data class PaywallInfo(
         closeReason = closeReason,
         surveys = surveys,
         presentation = presentation,
+        cacheKey = cacheKey,
+        buildId = buildId,
     )
 
     fun eventParams(


### PR DESCRIPTION
## Changes in this pull request

- Adds `cache_key` and `build_id`
- Adds cleanup of the `List` and `Map` properties on events being tracked

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)