### PR TITLE
SW-2919: Add custom_placement event support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Adds support for multiple paywall URLs, in case one CDN provider fails.
 - `ActivityEncapsulatable` now uses a WeakReference instead of a reference
+- SW-2919: Adds a `custom_placement` event that you can attach to any element in the paywall with a dictionary of parameters. When the element is tapped, the event will be tracked. The name of the placement can be used to trigger a paywall and its params used in audience filters.
+
 
 ## 1.2.1
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -573,6 +573,23 @@ class Superwall(
                     is Custom -> {
                         dependencyContainer.delegateAdapter.handleCustomPaywallAction(name = paywallEvent.string)
                     }
+
+                    is PaywallWebEvent.CustomPlacement -> {
+                        track(
+                            InternalSuperwallEvent.CustomPlacement(
+                                placementName = paywallEvent.name,
+                                params =
+                                    paywallEvent.params.let {
+                                        val map = mutableMapOf<String, Any>()
+                                        for (key in it.keys()) {
+                                            map[key] = it.get(key)
+                                        }
+                                        map
+                                    },
+                                paywallInfo = paywallView.info,
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -54,14 +54,14 @@ suspend fun Superwall.track(event: Trackable): TrackingResult {
                 logLevel = LogLevel.debug,
                 scope = LogScope.events,
                 message = "Logged Event",
-                info = parameters.eventParams,
+                info = parameters.audienceFilterParams,
             )
         }
 
         val eventData =
             EventData(
                 name = event.rawName,
-                parameters = parameters.eventParams,
+                parameters = parameters.audienceFilterParams,
                 createdAt = eventCreatedAt,
             )
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingParameters.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingParameters.kt
@@ -2,13 +2,13 @@ package com.superwall.sdk.analytics.internal
 
 data class TrackingParameters(
     val delegateParams: Map<String, Any>,
-    val eventParams: Map<String, Any>,
+    val audienceFilterParams: Map<String, Any>,
 ) {
     companion object {
         fun stub(): TrackingParameters =
             TrackingParameters(
                 delegateParams = emptyMap(),
-                eventParams = emptyMap(),
+                audienceFilterParams = emptyMap(),
             )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/Trackable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/Trackable.kt
@@ -2,7 +2,7 @@ package com.superwall.sdk.analytics.internal.trackable
 
 interface Trackable {
     val rawName: String
-    val customParameters: Map<String, Any>
+    val audienceFilterParams: Map<String, Any>
     val canImplicitlyTriggerPaywall: Boolean
 
     suspend fun getSuperwallParameters(): Map<String, Any>

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -37,7 +37,7 @@ sealed class InternalSuperwallEvent(
         get() = this.superwallEvent.canImplicitlyTriggerPaywall
 
     class AppOpen(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.AppOpen()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
@@ -45,7 +45,7 @@ sealed class InternalSuperwallEvent(
     class AppInstall(
         val appInstalledAtString: String,
         val hasExternalPurchaseController: Boolean,
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.AppInstall()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(
@@ -57,7 +57,7 @@ sealed class InternalSuperwallEvent(
     // TODO: Implement the rest
 
     class SurveyClose(
-        override val customParameters: MutableMap<String, Any> = mutableMapOf(),
+        override val audienceFilterParams: MutableMap<String, Any> = mutableMapOf(),
     ) : InternalSuperwallEvent(SuperwallEvent.SurveyClose()) {
         override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
     }
@@ -84,9 +84,9 @@ sealed class InternalSuperwallEvent(
                     paywallInfo,
                 )
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                val output = paywallInfo.customParams()
+                val output = paywallInfo.audienceFilterParams()
                 return output +
                     mapOf(
                         "survey_selected_option_title" to selectedOption.title,
@@ -107,15 +107,15 @@ sealed class InternalSuperwallEvent(
     }
 
     class AppLaunch(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.AppLaunch()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
 
     class Attributes(
         val appInstalledAtString: String,
-        override var customParameters: HashMap<String, Any> = HashMap(),
-    ) : InternalSuperwallEvent(SuperwallEvent.UserAttributes(customParameters)) {
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
+    ) : InternalSuperwallEvent(SuperwallEvent.UserAttributes(audienceFilterParams)) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(
                 "application_installed_at" to appInstalledAtString,
@@ -123,14 +123,14 @@ sealed class InternalSuperwallEvent(
     }
 
     class IdentityAlias(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.IdentityAlias()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
 
     class DeepLink(
         val uri: Uri,
-        override var customParameters: HashMap<String, Any> = extractQueryParameters(uri),
+        override var audienceFilterParams: HashMap<String, Any> = extractQueryParameters(uri),
     ) : InternalSuperwallEvent(SuperwallEvent.DeepLink(uri)) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(
@@ -174,13 +174,13 @@ sealed class InternalSuperwallEvent(
     }
 
     class FirstSeen(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.FirstSeen()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
 
     class AppClose(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.AppClose()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
@@ -226,10 +226,10 @@ sealed class InternalSuperwallEvent(
                         )
                 }
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() =
                 when (state) {
-                    is State.Complete -> state.paywallInfo.customParams()
+                    is State.Complete -> state.paywallInfo.audienceFilterParams()
                     else -> emptyMap()
                 }
 
@@ -255,7 +255,7 @@ sealed class InternalSuperwallEvent(
 
     class SubscriptionStatusDidChange(
         val subscriptionStatus: SubscriptionStatus,
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.SubscriptionStatusDidChange()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(
@@ -264,14 +264,14 @@ sealed class InternalSuperwallEvent(
     }
 
     class SessionStart(
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.SessionStart()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
     }
 
     class DeviceAttributes(
         val deviceAttributes: HashMap<String, Any>,
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.DeviceAttributes(attributes = deviceAttributes)) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = deviceAttributes
     }
@@ -279,7 +279,7 @@ sealed class InternalSuperwallEvent(
     class TriggerFire(
         val triggerResult: InternalTriggerResult,
         val triggerName: String,
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(
             SuperwallEvent.TriggerFire(
                 eventName = triggerName,
@@ -338,7 +338,7 @@ sealed class InternalSuperwallEvent(
         val status: PaywallPresentationRequestStatus,
         val statusReason: PaywallPresentationRequestStatusReason?,
         val factory: PresentationRequest.Factory,
-        override var customParameters: HashMap<String, Any> = HashMap(),
+        override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(
             SuperwallEvent.PaywallPresentationRequest(
                 status = status,
@@ -362,9 +362,9 @@ sealed class InternalSuperwallEvent(
     class PaywallOpen(
         val paywallInfo: PaywallInfo,
     ) : InternalSuperwallEvent(SuperwallEvent.PaywallOpen(paywallInfo = paywallInfo)) {
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap(paywallInfo.eventParams())
@@ -374,9 +374,9 @@ sealed class InternalSuperwallEvent(
         val paywallInfo: PaywallInfo,
         val surveyPresentationResult: SurveyPresentationResult,
     ) : InternalSuperwallEvent(SuperwallEvent.PaywallClose(paywallInfo)) {
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> {
@@ -400,9 +400,9 @@ sealed class InternalSuperwallEvent(
     ) : InternalSuperwallEvent(SuperwallEvent.PaywallDecline(paywallInfo = paywallInfo)) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap(paywallInfo.eventParams())
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
     }
 
@@ -437,9 +437,9 @@ sealed class InternalSuperwallEvent(
             class Timeout : State()
         }
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams().let {
+                return paywallInfo.audienceFilterParams().let {
                     if (superwallEvent is SuperwallEvent.TransactionAbandon) {
                         it.plus("abandoned_product_id" to (product?.productIdentifier ?: ""))
                     } else {
@@ -543,9 +543,9 @@ sealed class InternalSuperwallEvent(
                 paywallInfo = paywallInfo,
             ),
         ) {
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap(paywallInfo.eventParams(product))
@@ -560,9 +560,9 @@ sealed class InternalSuperwallEvent(
                 paywallInfo = paywallInfo,
             ),
         ) {
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap(paywallInfo.eventParams(product))
@@ -580,9 +580,9 @@ sealed class InternalSuperwallEvent(
                 paywallInfo = paywallInfo,
             ),
         ) {
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap(paywallInfo.eventParams(product))
@@ -636,9 +636,9 @@ sealed class InternalSuperwallEvent(
                     }
                 }
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> {
@@ -703,9 +703,9 @@ sealed class InternalSuperwallEvent(
                         )
                 }
 
-        override val customParameters: Map<String, Any>
+        override val audienceFilterParams: Map<String, Any>
             get() {
-                return paywallInfo.customParams()
+                return paywallInfo.audienceFilterParams()
             }
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> {
@@ -731,13 +731,13 @@ sealed class InternalSuperwallEvent(
     }
 
     object ConfigRefresh : InternalSuperwallEvent(SuperwallEvent.ConfigRefresh) {
-        override val customParameters: Map<String, Any> = emptyMap()
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
     }
 
     object Reset : InternalSuperwallEvent(SuperwallEvent.Reset) {
-        override val customParameters: Map<String, Any> = emptyMap()
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
     }
@@ -770,8 +770,25 @@ sealed class InternalSuperwallEvent(
                 }
             }
 
-        override val customParameters: Map<String, Any>
-            get() = paywallInfo.customParams()
+        override val audienceFilterParams: Map<String, Any>
+            get() = paywallInfo.audienceFilterParams()
+    }
+
+    data class CustomPlacement(
+        val placementName: String,
+        val paywallInfo: PaywallInfo,
+        val params: Map<String, Any>,
+    ) : InternalSuperwallEvent(SuperwallEvent.CustomPlacement) {
+        override val audienceFilterParams: Map<String, Any>
+            get() = paywallInfo.audienceFilterParams() + params
+
+        override val rawName: String
+            get() = placementName
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> =
+            paywallInfo.eventParams() + params + mapOf("name" to placementName)
+
+        override val canImplicitlyTriggerPaywall: Boolean = true
     }
 
     internal data class ErrorThrown(
@@ -785,7 +802,7 @@ sealed class InternalSuperwallEvent(
             System.currentTimeMillis(),
         )
 
-        override val customParameters: Map<String, Any> = emptyMap()
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters() =
             mapOf(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/UserIntiatedEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/UserIntiatedEvents.kt
@@ -5,7 +5,7 @@ interface TrackableUserInitiatedEvent : Trackable
 sealed class UserInitiatedEvent(
     override val rawName: String,
     override val canImplicitlyTriggerPaywall: Boolean,
-    override var customParameters: Map<String, Any> = emptyMap(),
+    override var audienceFilterParams: Map<String, Any> = emptyMap(),
     val isFeatureGatable: Boolean,
 ) : TrackableUserInitiatedEvent {
     class Track(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -379,6 +379,10 @@ sealed class SuperwallEvent {
             get() = "reset"
     }
 
+    object CustomPlacement : SuperwallEvent() {
+        override val rawName: String = SuperwallEvents.CustomPlacement.rawName
+    }
+
     object ErrorThrown : SuperwallEvent() {
         override val rawName: String
             get() = "error_thrown"

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -46,4 +46,5 @@ enum class SuperwallEvents(
     RestoreStart("restore_start"),
     RestoreFail("restore_fail"),
     RestoreComplete("restore_complete"),
+    CustomPlacement("custom_placement"),
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -381,7 +381,7 @@ class DependencyContainer(
     override fun makeUserAttributesEvent(): InternalSuperwallEvent.Attributes =
         InternalSuperwallEvent.Attributes(
             appInstalledAtString = deviceHelper.appInstalledAtString,
-            customParameters = HashMap(identityManager.userAttributes),
+            audienceFilterParams = HashMap(identityManager.userAttributes),
         )
 
     override fun makeHasExternalPurchaseController(): Boolean = storeKitManager.purchaseController.hasExternalPurchaseController

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -146,7 +146,7 @@ data class PaywallInfo(
         product: StoreProduct? = null,
         otherParams: Map<String, Any?>? = null,
     ): Map<String, Any> {
-        var output = customParams()
+        var output = audienceFilterParams()
 
         val params =
             mutableMapOf(
@@ -211,8 +211,8 @@ data class PaywallInfo(
         return output
     }
 
-    // / Parameters that can be used in rules.
-    fun customParams(): MutableMap<String, Any> {
+    // Parameters that can be used in audience filters.
+    fun audienceFilterParams(): MutableMap<String, Any> {
         val featureGatingSerialized =
             Json {}.encodeToString(FeatureGatingBehavior.serializer(), featureGatingBehavior)
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/PublicGetPresentationResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/PublicGetPresentationResult.kt
@@ -44,7 +44,7 @@ internal suspend fun Superwall.internallyGetPresentationResult(
     val eventData =
         EventData(
             name = event.rawName,
-            parameters = parameters.eventParams,
+            parameters = parameters.audienceFilterParams,
             createdAt = eventCreatedAt,
         )
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
@@ -46,6 +46,11 @@ sealed class PaywallMessage {
         val data: String,
     ) : PaywallMessage()
 
+    data class CustomPlacement(
+        val name: String,
+        val params: JSONObject,
+    ) : PaywallMessage()
+
     object PaywallOpen : PaywallMessage()
 
     object PaywallClose : PaywallMessage()
@@ -82,7 +87,14 @@ private fun parsePaywallMessage(json: JSONObject): PaywallMessage {
                 json.getString("product"),
                 json.getString("product_identifier"),
             )
+
         "custom" -> PaywallMessage.Custom(json.getString("data"))
+        "register_placement" ->
+            PaywallMessage.CustomPlacement(
+                json.getString("name"),
+                json.getJSONObject("params"),
+            )
+
         else -> throw IllegalArgumentException("Unknown event name: $eventName")
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.json.JSONObject
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.Base64
@@ -146,6 +147,7 @@ class PaywallMessageHandler(
             }
 
             is PaywallMessage.Custom -> handleCustomEvent(message.data)
+            is PaywallMessage.CustomPlacement -> handleCustomPlacement(message.name, message.params)
             else -> {
                 Logger.debug(
                     LogLevel.error,
@@ -366,6 +368,13 @@ class PaywallMessageHandler(
             mapOf("custom_event" to customEvent),
         )
         delegate?.eventDidOccur(PaywallWebEvent.Custom(customEvent))
+    }
+
+    private fun handleCustomPlacement(
+        name: String,
+        params: JSONObject,
+    ) {
+        delegate?.eventDidOccur(PaywallWebEvent.CustomPlacement(name, params))
     }
 
     private fun detectHiddenPaywallEvent(

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallWebEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallWebEvent.kt
@@ -2,6 +2,7 @@ package com.superwall.sdk.paywall.vc.web_view.messaging
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.json.JSONObject
 import java.net.URL
 
 @Serializable
@@ -33,5 +34,11 @@ sealed class PaywallWebEvent {
     @SerialName("opened_deep_link")
     data class OpenedDeepLink(
         val url: URL,
+    ) : PaywallWebEvent()
+
+    @SerialName("custom_placement")
+    data class CustomPlacement(
+        val name: String,
+        val params: JSONObject,
     ) : PaywallWebEvent()
 }


### PR DESCRIPTION
## Changes in this pull request

- Adds a `custom_placement` event that you can attach to any element in the paywall with a dictionary of parameters. When the element is tapped, the event will be tracked. The name of the placement can be used to trigger a paywall and its params used in audience filters.
- Renames `customParams` to `audienceFilterParams`

 
### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)