### PR TITLE
Add locale identifier, platform wrapper versions, update x-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Adds support for multiple paywall URLs, in case one CDN provider fails.
 - `ActivityEncapsulatable` now uses a WeakReference instead of a reference
+- SW-2900: Adds Superwall.instance.localeIdentifier as a convenience variable that you can use to dynamically update the locale used for evaluating rules and getting localized paywalls.
 
 ## 1.2.1
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -78,6 +78,12 @@ class Superwall(
 
     internal val presentationItems: PresentationItems = PresentationItems()
 
+    var localeIdentifier: String?
+        get() = dependencyContainer.configManager.options.localeIdentifier
+        set(value) {
+            dependencyContainer.configManager.options.localeIdentifier = value
+        }
+
     /**
      * The presented paywall view.
      */
@@ -382,8 +388,12 @@ class Superwall(
     /**
      * Do not use this function, this is for internal use only.
      */
-    fun setPlatformWrapper(wrapper: String) {
+    fun setPlatformWrapper(
+        wrapper: String,
+        version: String,
+    ) {
         dependencyContainer.deviceHelper.platformWrapper = wrapper
+        dependencyContainer.deviceHelper.platformWrapperVersion = version
     }
 
     /**

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -258,7 +258,7 @@ class DependencyContainer(
         val headers =
             mapOf(
                 "Authorization" to auth,
-                "X-Platform" to "iOS",
+                "X-Platform" to "Android",
                 "X-Platform-Environment" to "SDK",
                 "X-Platform-Wrapper" to deviceHelper.platformWrapper,
                 "X-App-User-ID" to (identityManager.appUserId ?: ""),

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -140,6 +140,7 @@ class DeviceHelper(
         get() = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
     var platformWrapper: String = ""
+    var platformWrapperVersion: String = ""
 
     private val _locale: Locale = Locale.getDefault()
 
@@ -473,6 +474,8 @@ class DeviceHelper(
                 ipTimezone = geo?.timezone,
                 capabilities = capabilities.map { it.name },
                 capabilitiesConfig = capabilities.toJson(factory.json()),
+                platformWrapper = platformWrapper,
+                platformWrapperVersion = platformWrapperVersion,
             )
 
         return deviceTemplate.toDictionary()

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/DeviceTemplate.kt
@@ -61,6 +61,10 @@ data class DeviceTemplate(
     val capabilities: List<String>,
     @SerialName("capabilities_config")
     val capabilitiesConfig: JsonElement,
+    @SerialName("platform_wrapper")
+    val platformWrapper: String,
+    @SerialName("platform_wrapper_version")
+    val platformWrapperVersion: String,
 ) {
     fun toDictionary(): Map<String, Any> {
         val json = Json { encodeDefaults = true }


### PR DESCRIPTION
## Changes in this pull request

- SW-2900: Adds Superwall.instance.localeIdentifier as a convenience variable that you can use to dynamically update the locale used for evaluating rules and getting localized paywalls.
- SW-2918: Adds platform wrapper version
- SW-2926 && SW-2826: Set platform header to `Android`

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)