### PR TITLE
SW-2917: Track config attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 - SW-2919: Adds a `custom_placement` event that you can attach to any element in the paywall with a dictionary of parameters. When the element is tapped, the event will be tracked. The name of the placement can be used to trigger a paywall and its params used in audience filters.
 - Adds support for bottom sheet presentation style
 - Adds `build_id` and `cache_key` to `PaywallInfo`.
+- SW-2917: Tracks a `config_attributes` event after calling `Superwall.configure`, which contains info about the configuration of the SDK. This gets tracked whenever you set the delegate.
+- Adds in device attributes tracking after setting the interface style override.
 
 ## 1.2.1
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -422,7 +422,7 @@ class Superwall(
             dependencyContainer.deviceHelper.platformWrapper = wrapper
             dependencyContainer.deviceHelper.platformWrapperVersion = version
             ioScope.launch {
-                track(dependencyContainer.makeConfigAttributes())
+                track(InternalSuperwallEvent.DeviceAttributes(dependencyContainer.makeSessionDeviceAttributes()))
             }
         }
     }

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -84,6 +84,9 @@ class Superwall(
         get() = dependencyContainer.configManager.options.localeIdentifier
         set(value) {
             dependencyContainer.configManager.options.localeIdentifier = value
+            ioScope.launch {
+                track(dependencyContainer.makeConfigAttributes())
+            }
         }
 
     /**
@@ -106,6 +109,9 @@ class Superwall(
         get() = options.logging.level
         set(newValue) {
             options.logging.level = newValue
+            ioScope.launch {
+                track(dependencyContainer.makeConfigAttributes())
+            }
         }
 
     /**
@@ -121,6 +127,9 @@ class Superwall(
         get() = dependencyContainer.delegateAdapter.kotlinDelegate
         set(newValue) {
             dependencyContainer.delegateAdapter.kotlinDelegate = newValue
+            ioScope.launch {
+                track(dependencyContainer.makeConfigAttributes())
+            }
         }
 
     /**
@@ -130,6 +139,9 @@ class Superwall(
     fun setJavaDelegate(newValue: SuperwallDelegateJava?) {
         withErrorTracking {
             dependencyContainer.delegateAdapter.javaDelegate = newValue
+            ioScope.launch {
+                track(dependencyContainer.makeConfigAttributes())
+            }
         }
     }
 
@@ -409,6 +421,9 @@ class Superwall(
         withErrorTracking {
             dependencyContainer.deviceHelper.platformWrapper = wrapper
             dependencyContainer.deviceHelper.platformWrapperVersion = version
+            ioScope.launch {
+                track(dependencyContainer.makeConfigAttributes())
+            }
         }
     }
 
@@ -419,6 +434,9 @@ class Superwall(
     fun setInterfaceStyle(interfaceStyle: InterfaceStyle?) {
         withErrorTracking {
             dependencyContainer.deviceHelper.interfaceStyleOverride = interfaceStyle
+            ioScope.launch {
+                track(InternalSuperwallEvent.DeviceAttributes(dependencyContainer.makeSessionDeviceAttributes()))
+            }
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -275,9 +275,8 @@ sealed class InternalSuperwallEvent(
         val options: SuperwallOptions,
         val hasExternalPurchaseController: Boolean,
         val hasDelegate: Boolean,
-        val platformWrapper: String?,
     ) : InternalSuperwallEvent(SuperwallEvent.ConfigAttributes) {
-        override val customParameters: Map<String, Any> = emptyMap()
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -5,6 +5,8 @@ import com.superwall.sdk.analytics.superwall.SuperwallEvent
 import com.superwall.sdk.analytics.superwall.TransactionProduct
 import com.superwall.sdk.config.models.Survey
 import com.superwall.sdk.config.models.SurveyOption
+import com.superwall.sdk.config.options.SuperwallOptions
+import com.superwall.sdk.config.options.toMap
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.dependencies.ComputedPropertyRequestsFactory
 import com.superwall.sdk.dependencies.FeatureFlagsFactory
@@ -267,6 +269,33 @@ sealed class InternalSuperwallEvent(
         override var audienceFilterParams: HashMap<String, Any> = HashMap(),
     ) : InternalSuperwallEvent(SuperwallEvent.SessionStart()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> = HashMap()
+    }
+
+    class ConfigAttributes(
+        val options: SuperwallOptions,
+        val hasExternalPurchaseController: Boolean,
+        val hasDelegate: Boolean,
+        val platformWrapper: String?,
+    ) : InternalSuperwallEvent(SuperwallEvent.ConfigAttributes) {
+        override val customParameters: Map<String, Any> = emptyMap()
+
+        override suspend fun getSuperwallParameters(): HashMap<String, Any> {
+            val params: Map<String, Any> =
+                listOfNotNull(
+                    "using_purchase_controller" to hasExternalPurchaseController,
+                    "has_delegate" to hasDelegate,
+                    platformWrapper?.let {
+                        "platform_wrapper" to it
+                    },
+                ).toMap()
+            return hashMapOf(
+                *options
+                    .toMap()
+                    .plus(params)
+                    .toList()
+                    .toTypedArray(),
+            )
+        }
     }
 
     class DeviceAttributes(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -279,23 +279,18 @@ sealed class InternalSuperwallEvent(
     ) : InternalSuperwallEvent(SuperwallEvent.ConfigAttributes) {
         override val customParameters: Map<String, Any> = emptyMap()
 
-        override suspend fun getSuperwallParameters(): HashMap<String, Any> {
-            val params: Map<String, Any> =
-                listOfNotNull(
-                    "using_purchase_controller" to hasExternalPurchaseController,
-                    "has_delegate" to hasDelegate,
-                    platformWrapper?.let {
-                        "platform_wrapper" to it
-                    },
-                ).toMap()
-            return hashMapOf(
+        override suspend fun getSuperwallParameters(): HashMap<String, Any> =
+            hashMapOf(
                 *options
                     .toMap()
-                    .plus(params)
-                    .toList()
+                    .plus(
+                        mapOf(
+                            "using_purchase_controller" to hasExternalPurchaseController,
+                            "has_delegate" to hasDelegate,
+                        ),
+                    ).toList()
                     .toTypedArray(),
             )
-        }
     }
 
     class DeviceAttributes(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -59,6 +59,11 @@ sealed class SuperwallEvent {
             get() = "session_start"
     }
 
+    object ConfigAttributes : SuperwallEvent() {
+        override val rawName: String
+            get() = "config_attributes"
+    }
+
     // / When device attributes are sent to the backend.
     data class DeviceAttributes(
         val attributes: Map<String, Any>,

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -47,4 +47,5 @@ enum class SuperwallEvents(
     RestoreFail("restore_fail"),
     RestoreComplete("restore_complete"),
     CustomPlacement("custom_placement"),
+    ConfigAttributes("config_attributes"),
 }

--- a/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
@@ -67,3 +67,19 @@ class PaywallOptions {
     // **Note:** This feature is still in development and could change.
     var transactionBackgroundView: TransactionBackgroundView? = TransactionBackgroundView.SPINNER
 }
+
+internal fun PaywallOptions.toMap() =
+    mapOf(
+        "is_haptic_feedback_enabled" to isHapticFeedbackEnabled,
+        "restore_failed" to
+            mapOf(
+                "title" to restoreFailed.title,
+                "message" to restoreFailed.message,
+                "close_button_title" to restoreFailed.closeButtonTitle,
+            ),
+        "should_show_purchase_failure_alert" to shouldShowPurchaseFailureAlert,
+        "should_preload" to shouldPreload,
+        "use_cached_templates" to useCachedTemplates,
+        "automatically_dismiss" to automaticallyDismiss,
+        "transaction_background_view" to transactionBackgroundView?.name,
+    )

--- a/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
@@ -85,3 +85,28 @@ class SuperwallOptions {
     // The log scope and level to print to the console.
     var logging: Logging = Logging()
 }
+
+internal fun SuperwallOptions.NetworkEnvironment.toMap(): Map<String, Any> =
+    listOfNotNull(
+        "host_domain" to hostDomain,
+        "base_host" to baseHost,
+        "collector_host" to collectorHost,
+        "scheme" to scheme,
+        port?.let { "port" to it },
+    ).toMap()
+
+internal fun SuperwallOptions.Logging.toMap(): Map<String, Any> =
+    mapOf(
+        "level" to level.toString(),
+        "scopes" to scopes.map { it.toString() },
+    )
+
+internal fun SuperwallOptions.toMap(): Map<String, Any> =
+    listOfNotNull(
+        "paywalls" to paywalls.toMap(),
+        "network_environment" to networkEnvironment.toMap(),
+        "is_external_data_collection_enabled" to isExternalDataCollectionEnabled,
+        localeIdentifier?.let { "locale_identifier" to it },
+        "is_game_controller_enabled" to isGameControllerEnabled,
+        "logging" to logging.toMap(),
+    ).toMap()

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -98,7 +98,8 @@ class DependencyContainer(
     AppSessionManager.Factory,
     DebugView.Factory,
     JavascriptEvaluator.Factory,
-    JsonFactory {
+    JsonFactory,
+    ConfigAttributesFactory {
     var network: Network
     override lateinit var api: Api
     override lateinit var deviceHelper: DeviceHelper
@@ -329,7 +330,9 @@ class DependencyContainer(
                             storage = storage,
                             webView = webView,
                             eventCallback = Superwall.instance,
-                            useMultipleUrls = configManager.config?.featureFlags?.enableMultiplePaywallUrls ?: false,
+                            useMultipleUrls =
+                                configManager.config?.featureFlags?.enableMultiplePaywallUrls
+                                    ?: false,
                         )
                     webView.delegate = paywallView
                     messageHandler.delegate = paywallView
@@ -516,4 +519,12 @@ class DependencyContainer(
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
 
     override suspend fun provideJavascriptEvaluator(context: Context) = evaluator
+
+    override fun makeConfigAttributes(): InternalSuperwallEvent.ConfigAttributes =
+        InternalSuperwallEvent.ConfigAttributes(
+            options = configManager.options,
+            hasExternalPurchaseController = makeHasExternalPurchaseController(),
+            hasDelegate = delegateAdapter.kotlinDelegate != null || delegateAdapter.javaDelegate != null,
+            platformWrapper = deviceHelper.platformWrapper,
+        )
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -525,6 +525,5 @@ class DependencyContainer(
             options = configManager.options,
             hasExternalPurchaseController = makeHasExternalPurchaseController(),
             hasDelegate = delegateAdapter.kotlinDelegate != null || delegateAdapter.javaDelegate != null,
-            platformWrapper = deviceHelper.platformWrapper,
         )
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -112,6 +112,10 @@ interface DeviceHelperFactory {
     suspend fun makeSessionDeviceAttributes(): HashMap<String, Any>
 }
 
+interface ConfigAttributesFactory {
+    fun makeConfigAttributes(): InternalSuperwallEvent.ConfigAttributes
+}
+
 interface UserAttributesEventFactory {
     fun makeUserAttributesEvent(): InternalSuperwallEvent.Attributes
 }


### PR DESCRIPTION
## Changes in this pull request

- SW-2917: Tracks a `config_attributes` event after calling `Superwall.configure`, which contains info about the configuration of the SDK. This gets tracked whenever you set the delegate.
- Adds in device attributes tracking after setting the interface style override.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)