### PR TITLE
Cleanup logs from println and Log.e/Log.d

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -4,6 +4,9 @@ import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.internal.trackable.Trackable
 import com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEvents
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.vc.PaywallView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -172,7 +175,11 @@ sealed class TrackingLogic {
             }
 
             if (!triggers.contains(event.rawName)) {
-                println("!! canTriggerPaywall: triggers.contains(event.rawName) ${event.rawName} $triggers")
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.all,
+                    "!! canTriggerPaywall: triggers.contains(event.rawName) ${event.rawName} $triggers",
+                )
                 return ImplicitTriggerOutcome.DontTriggerPaywall
             }
 
@@ -187,7 +194,11 @@ sealed class TrackingLogic {
             val referringEventName = paywallView?.info?.presentedByEventWithName
             if (referringEventName != null) {
                 if (notAllowedReferringEventNames.contains(referringEventName)) {
-                    println("!! canTriggerPaywall: notAllowedReferringEventNames.contains(referringEventName) $referringEventName")
+                    Logger.debug(
+                        LogLevel.debug,
+                        LogScope.all,
+                        "!! canTriggerPaywall: notAllowedReferringEventNames.contains(referringEventName) $referringEventName",
+                    )
                     return ImplicitTriggerOutcome.DontTriggerPaywall
                 }
             }
@@ -206,7 +217,11 @@ sealed class TrackingLogic {
             }
 
             if (paywallView != null) {
-                println("!! canTriggerPaywall: paywallViewController != null")
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.all,
+                    "!! canTriggerPaywall: paywallViewController != null",
+                )
                 return ImplicitTriggerOutcome.DontTriggerPaywall
             }
 

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -469,10 +469,18 @@ class GoogleBillingWrapper(
         result: BillingResult,
         purchases: MutableList<Purchase>?,
     ) {
-        println("onPurchasesUpdated: $result")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.storeKitManager,
+            "onPurchasesUpdated: $result",
+        )
         if (result.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
             for (purchase in purchases) {
-                println("Purchase: $purchase")
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.storeKitManager,
+                    "Purchase: $purchase",
+                )
                 CoroutineScope(Dispatchers.IO).launch {
                     purchaseResults.emit(
                         InternalPurchaseResult.Purchased(purchase),
@@ -484,12 +492,20 @@ class GoogleBillingWrapper(
                 purchaseResults.emit(InternalPurchaseResult.Cancelled)
             }
 
-            println("User cancelled purchase")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.storeKitManager,
+                "User cancelled purchase",
+            )
         } else {
             CoroutineScope(Dispatchers.IO).launch {
                 purchaseResults.emit(InternalPurchaseResult.Failed(Exception(result.responseCode.toString())))
             }
-            println("Purchase failed")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.storeKitManager,
+                "Purchase failed",
+            )
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigLogic.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.config
 
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.assignment.Assignment
 import com.superwall.sdk.models.assignment.ConfirmableAssignment
 import com.superwall.sdk.models.config.Config
@@ -86,8 +89,16 @@ object ConfigLogic {
             groupIds.add(groupId)
             groupedTriggerRules.add(trigger.rules)
         }
-        println("!!! groupedTriggerRules")
-        println(groupedTriggerRules)
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.configManager,
+            "!!! groupedTriggerRules",
+        )
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.configManager,
+            groupedTriggerRules.toString(),
+        )
         return groupedTriggerRules
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/deprecated/PaywallMessages.kt
+++ b/superwall/src/main/java/com/superwall/sdk/deprecated/PaywallMessages.kt
@@ -1,7 +1,9 @@
 package com.superwall.sdk.deprecated
 
 import android.net.Uri
-import android.util.Log
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import org.json.JSONObject
 import java.net.URL
 
@@ -47,7 +49,11 @@ sealed class PaywallMessage {
 }
 
 fun parseWrappedPaywallMessages(jsonString: String): WrappedPaywallMessages {
-    Log.d("SWWebViewInterface", jsonString)
+    Logger.debug(
+        LogLevel.debug,
+        LogScope.all,
+        "SWWebViewInterface:$jsonString",
+    )
     val jsonObject = JSONObject(jsonString)
     val version = jsonObject.optInt("version", 1)
     val payloadJson = jsonObject.getJSONObject("payload")

--- a/superwall/src/main/java/com/superwall/sdk/misc/CurrentActivityTracker.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/CurrentActivityTracker.kt
@@ -3,6 +3,9 @@ package com.superwall.sdk.misc
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 
 class CurrentActivityTracker :
     Application.ActivityLifecycleCallbacks,
@@ -13,16 +16,28 @@ class CurrentActivityTracker :
         activity: Activity,
         savedInstanceState: Bundle?,
     ) {
-        println("!! onActivityCreated: $activity")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.all,
+            "!! onActivityCreated: $activity",
+        )
     }
 
     override fun onActivityStarted(activity: Activity) {
-        println("!! onActivityStarted: $activity")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.all,
+            "!! onActivityStarted: $activity",
+        )
         currentActivity = activity
     }
 
     override fun onActivityResumed(activity: Activity) {
-        println("!! onActivityResumed: $activity")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.all,
+            "!! onActivityResumed: $activity",
+        )
         currentActivity = activity
     }
 
@@ -36,14 +51,22 @@ class CurrentActivityTracker :
     ) {}
 
     override fun onActivityDestroyed(activity: Activity) {
-        println("!! onActivityDestroyed: $activity")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.all,
+            "!! onActivityDestroyed: $activity",
+        )
         if (currentActivity == activity) {
             currentActivity = null
         }
     }
 
     override fun getCurrentActivity(): Activity? {
-        println("!! getCurrentActivity: $currentActivity")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.all,
+            "!! getCurrentActivity: $currentActivity",
+        )
         return currentActivity
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/models/serialization/AnyMapSerializer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/serialization/AnyMapSerializer.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.models.serialization
 
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
@@ -39,7 +42,11 @@ object AnyMapSerializer : KSerializer<Map<String, Any?>> {
                         else -> {
                             // TODO: Figure out when this is happening
                             put(k, JsonNull)
-                            println("!! Warning: Unsupported type ${v::class}, skipping...")
+                            Logger.debug(
+                                LogLevel.debug,
+                                LogScope.all,
+                                "!! Warning: Unsupported type ${v::class}, skipping...",
+                            )
 //                        throw SerializationException("$v is not supported")
                         }
                     }

--- a/superwall/src/main/java/com/superwall/sdk/models/serialization/AnySerializer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/serialization/AnySerializer.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.models.serialization
 
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
@@ -48,7 +51,11 @@ object AnySerializer : KSerializer<Any> {
             }
             null -> encoder.encodeNull()
             else -> {
-                println("Warning: Unsupported type ${value::class}, skipping...")
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.all,
+                    "Warning: Unsupported type ${value::class}, skipping...",
+                )
                 encoder.encodeNull()
             }
         }

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -11,7 +11,6 @@ import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
-import android.util.Log
 import androidx.core.content.ContextCompat
 import com.superwall.sdk.BuildConfig
 import com.superwall.sdk.Superwall
@@ -123,7 +122,11 @@ class DeviceHelper(
                 val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
                 packageInfo.versionName
             } catch (e: PackageManager.NameNotFoundException) {
-                Log.e("DeviceHelper", "Failed to load version info", e)
+                Logger.debug(
+                    LogLevel.error,
+                    LogScope.device,
+                    "DeviceHelper: Failed to load version info - $e",
+                )
                 ""
             }
 

--- a/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
@@ -111,7 +111,11 @@ class CustomHttpUrlConnection {
             responseMessage = request.inputStream.bufferedReader().use { it.readText() }
             request.disconnect()
         } else {
-            println("!!!Error: ${request.responseCode}")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.network,
+                "!!!Error: ${request.responseCode}",
+            )
             request.disconnect()
             throw NetworkError.Unknown()
         }
@@ -154,7 +158,11 @@ class CustomHttpUrlConnection {
                         "request_duration" to requestDuration,
                     ),
                 )
-                println("!!!Error: ${e.message}")
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.network,
+                    "!!!Error: ${e.message}",
+                )
                 throw NetworkError.Decoding()
             }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorParams.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorParams.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator
 
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import kotlinx.serialization.SerializationException
 import org.json.JSONObject
 import java.util.*
@@ -18,7 +21,11 @@ data class LiquidExpressionEvaluatorParams(
     fun toBase64Input(): String? =
         try {
             val jsonString = toJson()
-            println("!! jsonString: $jsonString")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.all,
+                "!! jsonString: $jsonString",
+            )
             jsonString.encodeToByteArray().toBase64()
         } catch (e: SerializationException) {
             null

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/NoSupportedEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/NoSupportedEvaluator.kt
@@ -1,7 +1,8 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.javascript
 
-import android.util.Log
 import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.triggers.TriggerRule
 import com.superwall.sdk.models.triggers.TriggerRuleOutcome
 import com.superwall.sdk.models.triggers.UnmatchedRule
@@ -11,7 +12,11 @@ object NoSupportedEvaluator : JavascriptEvaluator {
         base64params: String,
         rule: TriggerRule,
     ): TriggerRuleOutcome {
-        Log.e(LogLevel.warn.toString(), "Javascript sandbox and Webview are unsupported, nothing was evaluated.")
+        Logger.debug(
+            LogLevel.warn,
+            LogScope.jsEvaluator,
+            "Javascript sandbox and Webview are unsupported, nothing was evaluated.",
+        )
         return TriggerRuleOutcome.noMatch(
             UnmatchedRule.Source.EXPRESSION,
             rule.experiment.id,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallRequestManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallRequestManager.kt
@@ -5,6 +5,9 @@ import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.dependencies.ConfigManagerFactory
 import com.superwall.sdk.dependencies.DeviceInfoFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.network.Network
@@ -107,7 +110,11 @@ class PaywallRequestManager(
     suspend fun getRawPaywall(request: PaywallRequest): Paywall =
 
         withContext(ioScope.coroutineContext) {
-            println("!!getRawPaywall - ${request.responseIdentifiers.paywallId}")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.all,
+                "!!getRawPaywall - ${request.responseIdentifiers.paywallId}",
+            )
             trackResponseStarted(event = request.eventData)
             val paywall = getPaywallResponse(request)
 
@@ -147,13 +154,21 @@ class PaywallRequestManager(
                     throw errorResponse
                 }
 
-            println("!!getPaywallResponse - $paywallId - $paywall")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.all,
+                "!!getPaywallResponse - $paywallId - $paywall",
+            )
 
             paywall.experiment = request.responseIdentifiers.experiment
             paywall.responseLoadingInfo.startAt = responseLoadStartTime
             paywall.responseLoadingInfo.endAt = Date()
 
-            println("!!getPaywallResponse - $paywallId - $paywall - ${paywall.experiment}")
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.all,
+                "!!getPaywallResponse - $paywallId - $paywall - ${paywall.experiment}",
+            )
 
             return@withContext paywall
         }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -139,7 +139,11 @@ class SWWebView(
 
         // Use the new URL
         val urlString = newUri.toString()
-        println("SWWebView.loadUrl: $urlString")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.paywallView,
+            "SWWebView.loadUrl: $urlString",
+        )
         super.loadUrl(urlString)
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
@@ -1,7 +1,9 @@
 package com.superwall.sdk.paywall.vc.web_view
 
 import android.net.Uri
-import android.util.Log
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import org.json.JSONObject
 import java.net.URL
 
@@ -57,7 +59,11 @@ sealed class PaywallMessage {
 }
 
 fun parseWrappedPaywallMessages(jsonString: String): WrappedPaywallMessages {
-    Log.d("SWWebViewInterface", jsonString)
+    Logger.debug(
+        LogLevel.debug,
+        LogScope.superwallCore,
+        "SWWebViewInterface $jsonString",
+    )
     val jsonObject = JSONObject(jsonString)
     val version = jsonObject.optInt("version", 1)
     val payloadJson = jsonObject.getJSONObject("payload")

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -1,7 +1,6 @@
 package com.superwall.sdk.paywall.vc.web_view.messaging
 
 import TemplateLogic
-import android.util.Log
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import com.superwall.sdk.Superwall
@@ -69,7 +68,11 @@ class PaywallMessageHandler(
     @JavascriptInterface
     fun postMessage(message: String) {
         // Print out the message to the console using Log.d
-        Log.d("SWWebViewInterface", message)
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.superwallCore,
+            "SWWebViewInterface: $message",
+        )
 
         // Attempt to parse the message to json
         // and print out the version number
@@ -77,13 +80,21 @@ class PaywallMessageHandler(
         try {
             wrappedPaywallMessages = parseWrappedPaywallMessages(message)
         } catch (e: Throwable) {
-            Log.e("SWWebViewInterface", "Error parsing message", e)
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.superwallCore,
+                "SWWebViewInterface: Error parsing message - $e",
+            )
             return
         }
 
         // Loop through the messages and print out the event name
         for (paywallMessage in wrappedPaywallMessages.payload.messages) {
-            Log.d("SWWebViewInterface", paywallMessage.javaClass.simpleName)
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.superwallCore,
+                "SWWebViewInterface: ${paywallMessage.javaClass.simpleName}",
+            )
             handle(paywallMessage)
         }
     }

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -70,7 +70,11 @@ class TransactionManager(
             }
 
         val rawStoreProduct = product.rawStoreProduct
-        println("!!! Purchasing product ${rawStoreProduct.hasFreeTrial}")
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.paywallTransactions,
+            "!!! Purchasing product ${rawStoreProduct.hasFreeTrial}",
+        )
         val productDetails = rawStoreProduct.underlyingProductDetails
         val activity = activityProvider.getCurrentActivity() ?: return
 

--- a/superwall/src/main/java/com/superwall/sdk/view/SWWebViewInterface.kt
+++ b/superwall/src/main/java/com/superwall/sdk/view/SWWebViewInterface.kt
@@ -1,11 +1,13 @@
 package com.superwall.sdk.view
 
 import android.content.Context
-import android.util.Log
 import android.webkit.JavascriptInterface
 import com.superwall.sdk.deprecated.PaywallMessage
 import com.superwall.sdk.deprecated.WrappedPaywallMessages
 import com.superwall.sdk.deprecated.parseWrappedPaywallMessages
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 
 interface PaywallMessageDelegate {
     fun didReceiveMessage(message: PaywallMessage)
@@ -20,7 +22,12 @@ class SWWebViewInterface(
     @JavascriptInterface
     fun postMessage(message: String) {
         // Print out the message to the console using Log.d
-        Log.d("SWWebViewInterface", message)
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.superwallCore,
+            "SWWebViewInterface",
+            message,
+        )
 
         // Attempt to parse the message to json
         // and print out the version number
@@ -28,13 +35,21 @@ class SWWebViewInterface(
         try {
             wrappedPaywallMessages = parseWrappedPaywallMessages(message)
         } catch (e: Throwable) {
-            Log.e("SWWebViewInterface", "Error parsing message", e)
+            Logger.debug(
+                LogLevel.error,
+                LogScope.superwallCore,
+                "SWWebViewInterface: Error parsing message$e",
+            )
             return
         }
 
         // Loop through the messages and print out the event name
         for (paywallMessage in wrappedPaywallMessages.payload.messages) {
-            Log.d("SWWebViewInterface", paywallMessage.javaClass.simpleName)
+            Logger.debug(
+                LogLevel.debug,
+                LogScope.superwallCore,
+                "SWWebViewInterface:" + paywallMessage.javaClass.simpleName,
+            )
             delegate.didReceiveMessage(paywallMessage)
         }
     }


### PR DESCRIPTION
## Changes in this pull request

- Cleans up logs from `println` and `android.Log` to use our Logger

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)