### PR TITLE
Fix SDK lazy initialisation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.2.5
+
+### Fixes
+- Resolves issue where users would get `UninitializedPropertyAccessException` when calling `Superwall.instance` 
+
 ## 1.2.4
 
 ### Enhancements

--- a/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
@@ -1,6 +1,5 @@
 package com.superwall.sdk.analytics.internal
 
-import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
@@ -51,7 +50,17 @@ class TrackingLogicTest {
             val attributes = deviceHelper.getTemplateDevice()
             val event = InternalSuperwallEvent.DeviceAttributes(HashMap(attributes))
             val res = TrackingLogic.processParameters(event, "appSessionId")
-            Log.e("res", res.toString())
-            assert(res.audienceFilterParams.isEmpty())
+            assert(
+                lazyMessage = { "Lists should be cleaned" },
+                value = res.audienceFilterParams.none { it.value is List<*> },
+            )
+            assert(
+                lazyMessage = { "Booleans should be serialized as booleans" },
+                value = res.audienceFilterParams["\$is_standard_event"] == true,
+            )
+            assert(
+                lazyMessage = { "Double should be serialized as double" },
+                value = res.audienceFilterParams["\$totalPaywallViews"] == 0.0,
+            )
         }
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
@@ -52,6 +52,6 @@ class TrackingLogicTest {
             val event = InternalSuperwallEvent.DeviceAttributes(HashMap(attributes))
             val res = TrackingLogic.processParameters(event, "appSessionId")
             Log.e("res", res.toString())
-            assert(res.eventParams.isEmpty())
+            assert(res.audienceFilterParams.isEmpty())
         }
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -136,7 +136,7 @@ sealed class TrackingLogic {
                     is List<*> -> null
                     is Map<*, *> -> value.mapValues { clean(it.value) }.filterValues { it != null }
                     is String -> value
-                    is Int, is Float, is Double, is Long, is Boolean -> value.toString()
+                    is Int, is Float, is Double, is Long, is Boolean -> value
                     else -> {
                         try {
                             Json.encodeToString(value)

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
@@ -770,7 +770,9 @@ internal class DebugViewActivity : AppCompatActivity() {
             view: View,
         ) {
             val key = UUID.randomUUID().toString()
-            Superwall.instance.viewStore().storeView(key, view)
+            Superwall.instance.dependencyContainer
+                .makeViewStore()
+                .storeView(key, view)
 
             val intent =
                 Intent(context, DebugViewActivity::class.java).apply {
@@ -799,7 +801,9 @@ internal class DebugViewActivity : AppCompatActivity() {
             return
         }
         val view =
-            Superwall.instance.viewStore().retrieveView(key) ?: run {
+            Superwall.instance.dependencyContainer
+                .makeViewStore()
+                .retrieveView(key) ?: run {
                 finish() // Close the activity if the view associated with the key is not found
                 return
             }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -28,6 +28,7 @@ import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
 import com.superwall.sdk.paywall.request.PaywallRequest
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.vc.PaywallView
+import com.superwall.sdk.paywall.vc.ViewStorage
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewDelegateAdapter
 import com.superwall.sdk.paywall.vc.web_view.templating.models.JsonVariables
 import com.superwall.sdk.storage.Storage
@@ -186,4 +187,8 @@ interface OptionsFactory {
 
 interface TriggerFactory {
     suspend fun makeTriggers(): Set<String>
+}
+
+internal interface ViewStoreFactory {
+    fun makeViewStore(): ViewStorage
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -32,6 +32,9 @@ import androidx.core.view.children
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.dependencies.DeviceHelperFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.isLightColor
 import com.superwall.sdk.models.paywall.LocalNotification
 import com.superwall.sdk.models.paywall.PaywallPresentationStyle
@@ -69,7 +72,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                 if (view.webView.parent == null) {
                     view.addView(view.webView)
                 }
-                val viewStorageViewModel = Superwall.instance.viewStore()
+                val viewStorageViewModel = Superwall.instance.dependencyContainer.makeViewStore()
                 // If we started it directly and the view does not have shimmer and loading attached
                 // We set them up for this PaywallView
                 if (view.children.none { it is LoadingView || it is ShimmerView }) {
@@ -182,7 +185,17 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             return
         }
 
-        val viewStorageViewModel = Superwall.instance.viewStore()
+        val viewStorageViewModel =
+            try {
+                Superwall.instance.dependencyContainer.makeViewStore()
+            } catch (e: Exception) {
+                Logger.debug(
+                    LogLevel.error,
+                    LogScope.paywallView,
+                    "Cannot access viewStore or create view - has Superwall been initialised?",
+                )
+                return
+            }
 
         val view =
             viewStorageViewModel.retrieveView(key) as? PaywallView ?: run {
@@ -250,6 +263,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             PaywallPresentationStyle.MODAL -> {
                 // TODO: Not yet supported in Android
             }
+
             PaywallPresentationStyle.NONE,
             PaywallPresentationStyle.DRAWER,
             null,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/ViewStorageViewModel.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap
 /*
 * Stores already loaded or preloaded paywalls
 * */
-internal class ViewStorageViewModel :
+class ViewStorageViewModel :
     ViewModel(),
     ViewStorage {
     override val views = ConcurrentHashMap<String, View>()

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -99,6 +99,9 @@ class SWWebView(
                 loadUrl = {
                     loadUrl(it.url)
                 },
+                stopLoading = {
+                    stopLoading()
+                },
             )
         this.webViewClient = client
         listenToWebviewClientEvents(this.webViewClient as DefaultWebviewClient)

--- a/superwall/src/main/java/com/superwall/sdk/view/SWWebViewInterface.kt
+++ b/superwall/src/main/java/com/superwall/sdk/view/SWWebViewInterface.kt
@@ -25,8 +25,7 @@ class SWWebViewInterface(
         Logger.debug(
             LogLevel.debug,
             LogScope.superwallCore,
-            "SWWebViewInterface",
-            message,
+            "SWWebViewInterface: $message",
         )
 
         // Attempt to parse the message to json


### PR DESCRIPTION
## Changes in this pull request

- As `lateinit var` should only be used to ensure compiler a var will be initialized, the current usage of keeping the instance as a `lateinit` can cause issues on reconfiguration
- This MR migrates it to a nullable private field, allowing it to be set again in case instance was lost
- Also migrates the `ViewStore` to `DependencyContainer` and creates a factory function to expose it via interface 

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)