### PR TITLE
Add support for old AGP versions

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -115,6 +115,25 @@ jobs:
           sudo git push -u origin release/${{steps.version.outputs.prop}}
         fi
 
+    - name: Run Autodowngrade Task
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        if [ "${{ steps.check-tag.outputs.tag-exists }}" == "false" ]; then
+          ./gradlew downgradeAgpTask
+        fi
+
+    - name: Deploy Downgraded Version
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        if [ "${{ steps.check-tag.outputs.tag-exists }}" == "false" ]; then
+          ./gradlew publish -Paws_access_key_id=$AWS_ACCESS_KEY_ID -Paws_secret_access_key=$AWS_SECRET_ACCESS_KEY -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD
+        fi
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
     - name: slack-send
       # Only notify on a new tag
       if: steps.check-tag.outputs.tag-exists == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## 1.2.4
 
 ### Enhancements
+- For users who are not able to upgrade their AGP or Gradle versions, we have added a new artifact `superwall-android-agp-7` which keeps compatibility.
+
+### Enhancements
 
 - Fixes issue with decoding custom placements from paywalls.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,7 @@ plugins {
     alias(libs.plugins.serialization) apply false
 }
 true
+
+buildscript {
+    apply(from = "./scripts/old-agp-auto-downgrade.gradle.kts")
+}

--- a/scripts/old-agp-auto-downgrade.gradle.kts
+++ b/scripts/old-agp-auto-downgrade.gradle.kts
@@ -1,0 +1,153 @@
+import java.io.File
+
+
+fun updateLibsVersions(
+    filePath: String,
+    oldAgpVersion: String,
+) {
+    val file = File(filePath)
+    val lines = file.readLines().toMutableList()
+
+    val versionUpdates =
+        mapOf(
+            "gradle_plugin_version" to oldAgpVersion,
+            "lifecycleProcessVersion" to "2.3.1",
+            "compose_version" to "2022.10.00",
+            "kotlinx_serialization_json_version" to "1.5.1",
+            "activity_compose_version" to "1.5.1",
+            "core_version" to "1.6.0",
+            "appcompat_version" to "1.6.1",
+            "material_version" to "1.8.0",
+            "core_ktx_version" to "1.6.0",
+            "lifecycle_runtime_ktx_version" to "2.3.1",
+            "kotlinx_coroutines_test_version" to "1.7.1",
+            "kotlin" to "1.8.21",
+            "kotlinx_coroutines_core_version" to "1.7.1",
+        )
+
+    val updatedLines =
+        lines.map { line ->
+            val trimmedLine = line.trim()
+            versionUpdates.entries
+                .find { (key, _) ->
+                    trimmedLine.matches(Regex("^$key\\s*=.*"))
+                }?.let { (key, value) ->
+                    "$key = \"$value\""
+                } ?: line
+        }
+
+    file.writeText(updatedLines.joinToString("\n"))
+}
+
+fun removeEdgeToEdgeReference() {
+    val file =
+        File("superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt")
+    val lines =
+        file
+            .readLines()
+            .map { line ->
+                if (line.contains("enableEdgeToEdge")) {
+                    null
+                } else {
+                    line
+                }
+            }.filterNotNull()
+            .toMutableList()
+    file.writeText(lines.joinToString("\n"))
+}
+
+fun fixViewModelStoreReference() {
+    val toWrite = "override fun getViewModelStore(): ViewModelStore"
+    val text =
+        File("superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallStoreOwner.kt").let {
+            val newText =
+                it.readText().replace("override val viewModelStore: ViewModelStore", toWrite)
+            it.writeText(newText)
+        }
+}
+
+fun replaceEntriesCall() {
+    val file = File("superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt")
+    val text = file.readText().replace(".entries.", ".values().")
+    file.writeText(text)
+}
+
+fun updateGradleWrapper(
+    filePath: String,
+    oldGradleVersion: String,
+) {
+    val file = File(filePath)
+    val content = file.readText()
+    val updatedContent =
+        content.replace(
+            Regex("distributionUrl=.*"),
+            "distributionUrl=https\\://services.gradle.org/distributions/gradle-$oldGradleVersion-bin.zip",
+        )
+    file.writeText(updatedContent)
+}
+
+fun updateBuildGradle(
+    filePath: String,
+    oldKotlinCompilerVersion: String,
+) {
+    val file = File(filePath)
+    val lines = file.readLines().toMutableList()
+
+    for (i in lines.indices) {
+        if (lines[i].contains("kotlinCompilerExtensionVersion = ")) {
+            lines[i] = "        kotlinCompilerExtensionVersion = \"$oldKotlinCompilerVersion\""
+        }
+    }
+
+    // Replace packaging block with tasks.withType
+    val packagingBlockStart = lines.indexOfFirst { it.contains("packaging {") }
+    if (packagingBlockStart != -1) {
+        val packagingBlockEnd =
+            lines
+                .subList(packagingBlockStart, lines.size)
+                .indexOfFirst { it.contains("}") } + packagingBlockStart
+        val newBlock =
+            """
+            tasks.withType<AbstractArchiveTask> {
+                exclude("META-INF/LICENSE.md")
+                exclude("META-INF/LICENSE-notice.md")
+            }
+            """.trimIndent()
+        lines.subList(packagingBlockStart, packagingBlockEnd + 1).clear()
+        lines.add(packagingBlockStart, newBlock)
+    }
+
+    file.writeText(lines.joinToString("\n"))
+}
+
+fun updateArtifactId(
+    filePath: String,
+    newArtifactId: String,
+) {
+    val file = File(filePath)
+    val txt = file.readText()
+    val updatedTxt =
+        txt.replace(
+            "artifactId = \"superwall-android\"",
+            "artifactId = \"$newArtifactId\"",
+        )
+    file.writeText(updatedTxt)
+}
+
+fun action() {
+    val projectDir = projectDir.toString()
+    updateLibsVersions("$projectDir/gradle/libs.versions.toml", "7.4.2")
+    updateGradleWrapper("$projectDir/gradle/wrapper/gradle-wrapper.properties", "7.5")
+    updateBuildGradle("$projectDir/superwall/build.gradle.kts", "1.4.7")
+    updateArtifactId("$projectDir/superwall/build.gradle.kts", "superwall-android-agp-7")
+    removeEdgeToEdgeReference()
+    fixViewModelStoreReference()
+    replaceEntriesCall()
+    println("AGP version update and artifactId change completed successfully.")
+}
+
+tasks.register("downgradeAgpTask") {
+    group = "custom"
+    description = "Downgrade AGP version and change artifactId"
+    action()
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewClientEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/WebviewClientEvent.kt
@@ -9,7 +9,7 @@ sealed class WebviewClientEvent {
         val webviewError: WebviewError,
     ) : WebviewClientEvent()
 
-    data object LoadingFallback : WebviewClientEvent()
+    object LoadingFallback : WebviewClientEvent()
 }
 
 sealed class WebviewError {
@@ -27,7 +27,7 @@ sealed class WebviewError {
         override fun toString(): String = "The webview has attempted to load too many times."
     }
 
-    data object NoUrls : WebviewError() {
+    object NoUrls : WebviewError() {
         override fun toString() = "There were no paywall URLs provided."
     }
 


### PR DESCRIPTION
## Changes in this pull request

- Adds a script to automatically downgrade, build and release `superwall-android-agp-7` artifact 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)