### PR TITLE
Fix paywall composable issues, add paywallView.setup() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.2.5
 
+### Enhancements
+- Adds a `Modifier` to `PaywallComposable` to allow for more control
+- Adds a `PaywallView.setup(...)` method to allow for easy setup when using `PaywallView` directly
+
 ### Fixes
-- Resolves issue where users would get `UninitializedPropertyAccessException` when calling `Superwall.instance` 
+- Fixes issue with displaying `PaywallComposable`
+- Resolves issue where users would get `UninitializedPropertyAccessException` when calling `Superwall.instance`
 
 ## 1.2.4
 

--- a/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/composable/PaywallComposable.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.paywall.presentation.get_paywall.getPaywall
 import com.superwall.sdk.paywall.presentation.internal.request.PaywallOverrides
+import com.superwall.sdk.paywall.vc.LoadingView
 import com.superwall.sdk.paywall.vc.PaywallView
+import com.superwall.sdk.paywall.vc.ShimmerView
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +30,7 @@ import java.lang.ref.WeakReference
 
 @Composable
 fun PaywallComposable(
+    modifier: Modifier = Modifier.fillMaxSize(),
     event: String,
     params: Map<String, Any>? = null,
     paywallOverrides: PaywallOverrides? = null,
@@ -57,6 +60,7 @@ fun PaywallComposable(
         try {
             val newView = Superwall.instance.getPaywall(event, params, paywallOverrides, delegate)
             newView.encapsulatingActivity = WeakReference(context as? Activity)
+            newView.setupWith(ShimmerView(context), LoadingView(context))
             newView.beforeViewCreated()
             viewState.value = newView
         } catch (e: Throwable) {
@@ -80,6 +84,7 @@ fun PaywallComposable(
                     }
                 }
                 AndroidView(
+                    modifier = modifier,
                     factory = { context ->
                         viewToRender
                     },

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -4,6 +4,7 @@ import ComputedPropertyRequest
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.webkit.WebSettings
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import com.android.billingclient.api.Purchase
@@ -255,6 +256,15 @@ class DependencyContainer(
                 factory = this,
                 context = context,
             )
+
+        /**
+         * This loads the webview libraries in the background thread, giving us 100-200ms less lag
+         * on first webview render.
+         * For more info check https://issuetracker.google.com/issues/245155339
+         */
+        ioScope.launch {
+            WebSettings.getDefaultUserAgent(context)
+        }
     }
 
     override suspend fun makeHeaders(

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
@@ -220,6 +220,18 @@ class PaywallView(
         loadingView.setupFor(this, loadingState)
     }
 
+    fun setupWith(
+        shimmerView: ShimmerView,
+        loadingView: LoadingView,
+    ) {
+        if (webView.parent == null) {
+            addView(webView)
+        }
+        this.shimmerView = shimmerView
+        this.loadingViewController = loadingView
+        layoutSubviews()
+    }
+
     fun present(
         presenter: Activity,
         request: PresentationRequest,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -76,11 +76,10 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                 // If we started it directly and the view does not have shimmer and loading attached
                 // We set them up for this PaywallView
                 if (view.children.none { it is LoadingView || it is ShimmerView }) {
-                    (viewStorageViewModel.retrieveView(LoadingView.TAG) as LoadingView)
-                        .let { view.setupLoading(it) }
-                    (viewStorageViewModel.retrieveView(ShimmerView.TAG) as ShimmerView)
-                        .let { view.setupShimmer(it) }
-                    view.layoutSubviews()
+                    val loading = (viewStorageViewModel.retrieveView(LoadingView.TAG) as LoadingView)
+
+                    val shimmer = (viewStorageViewModel.retrieveView(ShimmerView.TAG) as ShimmerView)
+                    view.setupWith(shimmer, loading)
                 }
                 val intent =
                     Intent(context, SuperwallPaywallActivity::class.java).apply {


### PR DESCRIPTION
## Changes in this pull request

- Fixes issue with displaying `PaywallComposable`
- Adds a `PaywallView.setup()` method for direct users of `PaywallView` to setup the views easily
- Adds passing in a `Modifier` to `PaywallComposable` to control composable size

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)