### PR TITLE
Fix paywall cache memory leak, ensure tracker uses a WeakReference

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/misc/CurrentActivityTracker.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/CurrentActivityTracker.kt
@@ -6,11 +6,12 @@ import android.os.Bundle
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
+import java.lang.ref.WeakReference
 
 class CurrentActivityTracker :
     Application.ActivityLifecycleCallbacks,
     ActivityProvider {
-    private var currentActivity: Activity? = null
+    private var currentActivity: WeakReference<Activity>? = null
 
     override fun onActivityCreated(
         activity: Activity,
@@ -29,7 +30,7 @@ class CurrentActivityTracker :
             LogScope.all,
             "!! onActivityStarted: $activity",
         )
-        currentActivity = activity
+        currentActivity = WeakReference(activity)
     }
 
     override fun onActivityResumed(activity: Activity) {
@@ -38,7 +39,7 @@ class CurrentActivityTracker :
             LogScope.all,
             "!! onActivityResumed: $activity",
         )
-        currentActivity = activity
+        currentActivity = WeakReference(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {}
@@ -67,6 +68,6 @@ class CurrentActivityTracker :
             LogScope.all,
             "!! getCurrentActivity: $currentActivity",
         )
-        return currentActivity
+        return currentActivity?.get()
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
@@ -19,7 +19,8 @@ class PaywallViewCache(
     private val activityProvider: ActivityProvider,
     private val deviceHelper: DeviceHelper,
 ) {
-    private val ctx: Context = activityProvider.getCurrentActivity() ?: appCtx
+    private val ctx: Context
+        get() = activityProvider.getCurrentActivity() ?: appCtx
     private var _activePaywallVcKey: String? = null
     private val loadingView: LoadingView = LoadingView(context = ctx)
     private val shimmerView: ShimmerView = ShimmerView(context = ctx)


### PR DESCRIPTION
## Changes in this pull request

- Fixes memory leak of activity in `PaywallCache` by ensuring it is always fetched from a `WeakReference`

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)