### PR TITLE
Downgrade minSDK to version 22

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "com.superwall.superapp"
-        minSdk = 26
+        minSdk = 22
         targetSdk = 34
         versionCode = 2
         versionName = "1.0.0"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -30,7 +30,7 @@ android {
     namespace = "com.superwall.sdk"
 
     defaultConfig {
-        minSdkVersion(26)
+        minSdkVersion(22)
         targetSdkVersion(33)
 
         aarMetadata {

--- a/superwall/src/main/AndroidManifest.xml
+++ b/superwall/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-sdk tools:overrideLibrary="androidx.javascriptengine"></uses-sdk>
 </manifest>

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -16,8 +16,8 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.net.URI
-import java.time.LocalDateTime
-import java.time.ZoneOffset
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneOffset
 import java.util.*
 
 sealed class TrackingLogic {

--- a/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
+++ b/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
@@ -4,13 +4,10 @@ import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import org.threeten.bp.Period
-import java.time.Duration
-import java.time.format.DateTimeParseException
+import org.threeten.bp.Duration
+import org.threeten.bp.format.DateTimeParseException
 import java.util.*
-import java.util.function.Function
-import java.util.function.IntPredicate
 import java.util.regex.Pattern
-import java.util.stream.Stream
 
 /*
  * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
@@ -55,6 +52,11 @@ import java.util.stream.Stream
  * This class is immutable and thread-safe.
  */
 object AmountFormats {
+
+
+    fun interface IntPredicate {
+        fun test(value: Int): Boolean
+    }
     /**
      * The number of days per week.
      */
@@ -172,7 +174,7 @@ object AmountFormats {
      * List of DurationUnit values ordered by longest suffix first.
      */
     private val DURATION_UNITS =
-        Arrays.asList(
+        listOf(
             DurationUnit("ns", Duration.ofNanos(1)),
             DurationUnit("µs", Duration.ofNanos(1000)), // U+00B5 = micro symbol
             DurationUnit("μs", Duration.ofNanos(1000)), // U+03BC = Greek letter mu
@@ -431,23 +433,23 @@ object AmountFormats {
         // consume the leading sign - or + if one is present.
         var sign = 1
         var updatedText = consumePrefix(durationText, '-')
-        if (updatedText.isPresent) {
+        if (updatedText.isSuccess) {
             sign = -1
             offset += 1
-            durationText = updatedText.get()
+            durationText = updatedText.getOrNull()!!
         } else {
             updatedText = consumePrefix(durationText, '+')
-            if (updatedText.isPresent) {
+            if (updatedText.isSuccess) {
                 offset += 1
             }
-            durationText = updatedText.orElse(durationText)
+            durationText = updatedText.getOrNull() ?: durationText
         }
         // special case for a string of "0"
         if (durationText == "0") {
             return Duration.ZERO
         }
         // special case, empty string as an invalid duration.
-        if (durationText.length == 0) {
+        if (durationText.isEmpty()) {
             throw DateTimeParseException("Not a numeric value", original, 0)
         }
         var value = Duration.ZERO
@@ -459,9 +461,9 @@ object AmountFormats {
             val leadingInt: DurationScalar = integerPart
             var fraction: DurationScalar = EMPTY_FRACTION
             val dot = consumePrefix(durationText, '.')
-            if (dot.isPresent) {
+            if (dot.isSuccess) {
                 offset += 1
-                durationText = dot.get()
+                durationText = dot.getOrNull()!!
                 val fractionPart = consumeDurationFraction(durationText, original, offset)
                 // update the remaining string and fraction.
                 offset += durationText.length - fractionPart.remainingText().length
@@ -469,14 +471,14 @@ object AmountFormats {
                 fraction = fractionPart
             }
             val optUnit = findUnit(durationText)
-            if (!optUnit.isPresent) {
+            if (optUnit.isFailure) {
                 throw DateTimeParseException(
                     "Invalid duration unit",
                     original,
                     offset,
                 )
             }
-            val unit = optUnit.get()
+            val unit = optUnit.getOrNull()!!
             try {
                 var unitValue = leadingInt.applyTo(unit)
                 val fractionValue = fraction.applyTo(unit)
@@ -591,27 +593,24 @@ object AmountFormats {
     }
 
     // find the duration unit at the beginning of the input text, if present.
-    private fun findUnit(text: CharSequence): Optional<DurationUnit> =
+    private fun findUnit(text: CharSequence): Result<DurationUnit> =
         DURATION_UNITS
-            .stream()
-            .sequential()
-            .filter { du: DurationUnit ->
+            .firstOrNull { du: DurationUnit ->
                 du.prefixMatchesUnit(
                     text,
                 )
-            }.findFirst()
+            }?.let { Result.success(it) } ?: Result.failure(Exception("No matching duration unit found"))
 
     // consume the indicated {@code prefix} if it exists at the beginning of the
-    // text, returning the
-    // remaining string if the prefix was consumed.
+    // text, returning the remaining string if the prefix was consumed.
     private fun consumePrefix(
         text: CharSequence,
         prefix: Char,
-    ): Optional<CharSequence> =
-        if (text.length > 0 && text[0] == prefix) {
-            Optional.of(text.subSequence(1, text.length))
+    ): Result<CharSequence> =
+        if (text.isNotEmpty() && text[0] == prefix) {
+            Result.success(text.subSequence(1, text.length))
         } else {
-            Optional.empty()
+            Result.failure(Exception("Prefix not found"))
         }
 
     // -------------------------------------------------------------------------
@@ -694,12 +693,9 @@ object AmountFormats {
 
         init {
             check(predicateStrs.size + 1 == text.size) { "Invalid word-based resource" }
-            predicates =
-                Stream
-                    .of<String>(*predicateStrs)
-                    .map { predicateStr ->
-                        findPredicate(predicateStr)
-                    }.toArray { size -> arrayOfNulls<IntPredicate>(size) }
+            predicates = predicateStrs.map { predicateStr ->
+                findPredicate(predicateStr!!)
+            }.toTypedArray()
             this.text = text
         }
 
@@ -723,8 +719,8 @@ object AmountFormats {
             }
             buf.append(value).append(text[predicates.size])
         }
-    }
 
+    }
     // -------------------------------------------------------------------------
     // data holder for a duration unit string and its associated Duration value.
     internal class DurationUnit constructor(
@@ -740,7 +736,7 @@ object AmountFormats {
         // scale the unit by the input scalingFunction, returning a value if
         // one is produced, or an empty result when the operation results in an
         // arithmetic overflow.
-        fun scaleBy(scaleFunc: Function<Duration, Duration?>): Duration? = scaleFunc.apply(value)
+        fun scaleBy(scaleFunc: (Duration) -> Duration?): Duration? = scaleFunc(value)
     }
 
     // interface for computing a duration from a duration unit and a scalar.
@@ -774,7 +770,7 @@ object AmountFormats {
 
     // data holder for the fractional floating point value of a duration
     // scalar.
-    internal class FractionScalarPart constructor(
+    internal class FractionScalarPart(
         private val value: Long,
         private val scale: Long,
     ) : DurationScalar {

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import java.text.SimpleDateFormat
-import java.time.Duration
 import java.util.Currency
 import java.util.Date
 import java.util.Locale
@@ -74,44 +73,39 @@ class DeviceHelper(
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private val appInfo = context.packageManager.getPackageInfo(context.packageName, 0)
     private val appInstallDate = Date(appInfo.firstInstallTime)
-
     private val daysSinceInstall: Int
         get() {
-            val fromDate = appInstallDate
-            val toDate = Date()
-            val fromInstant = fromDate.toInstant()
-            val toInstant = toDate.toInstant()
-            val duration = Duration.between(fromInstant, toInstant)
+            val fromDate = org.threeten.bp.Instant.ofEpochMilli(appInstallDate.time)
+            val toDate = org.threeten.bp.Instant.now()
+            val duration = org.threeten.bp.Duration.between(fromDate, toDate)
             return duration.toDays().toInt()
         }
 
     private val minutesSinceInstall: Int
         get() {
-            val fromDate = appInstallDate
-            val toDate = Date()
-            val fromInstant = fromDate.toInstant()
-            val toInstant = toDate.toInstant()
-            val duration = Duration.between(fromInstant, toInstant)
+            val fromDate = org.threeten.bp.Instant.ofEpochMilli(appInstallDate.time)
+            val toDate = org.threeten.bp.Instant.now()
+            val duration = org.threeten.bp.Duration.between(fromDate, toDate)
             return duration.toMinutes().toInt()
         }
 
     private val daysSinceLastPaywallView: Int?
         get() {
-            val fromDate = storage.read(LastPaywallView) ?: return null
-            val toDate = Date()
-            val fromInstant = fromDate.toInstant()
-            val toInstant = toDate.toInstant()
-            val duration = Duration.between(fromInstant, toInstant)
+            val fromDate =
+                storage.read(LastPaywallView)?.let { org.threeten.bp.Instant.ofEpochMilli(it.time) }
+                    ?: return null
+            val toDate = org.threeten.bp.Instant.now()
+            val duration = org.threeten.bp.Duration.between(fromDate, toDate)
             return duration.toDays().toInt()
         }
 
     private val minutesSinceLastPaywallView: Int?
         get() {
-            val fromDate = storage.read(LastPaywallView) ?: return null
-            val toDate = Date()
-            val fromInstant = fromDate.toInstant()
-            val toInstant = toDate.toInstant()
-            val duration = Duration.between(fromInstant, toInstant)
+            val fromDate =
+                storage.read(LastPaywallView)?.let { org.threeten.bp.Instant.ofEpochMilli(it.time) }
+                    ?: return null
+            val toDate = org.threeten.bp.Instant.now()
+            val duration = org.threeten.bp.Duration.between(fromDate, toDate)
             return duration.toMinutes().toInt()
         }
 
@@ -199,12 +193,20 @@ class DeviceHelper(
                 return ""
             }
 
-            val networkCapabilities =
-                connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-            return when {
-                networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> "Cellular"
-                networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true -> "Wifi"
-                else -> ""
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val networkCapabilities =
+                    connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                return when {
+                    networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> "Cellular"
+                    networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true -> "Wifi"
+                    else -> ""
+                }
+            } else {
+                when(connectivityManager.activeNetworkInfo?.type){
+                    ConnectivityManager.TYPE_MOBILE -> return "Cellular"
+                    ConnectivityManager.TYPE_WIFI -> return "Wifi"
+                    else -> return ""
+                }
             }
         }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorParams.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluatorParams.kt
@@ -1,11 +1,11 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator
 
+import android.util.Base64
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import kotlinx.serialization.SerializationException
 import org.json.JSONObject
-import java.util.*
 
 data class LiquidExpressionEvaluatorParams(
     val expression: String,
@@ -51,4 +51,4 @@ data class JavascriptExpressionEvaluatorParams(
         }
 }
 
-fun ByteArray.toBase64(): String = Base64.getEncoder().encodeToString(this)
+fun ByteArray.toBase64(): String = Base64.encodeToString(this, Base64.DEFAULT)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -23,6 +23,7 @@ import android.widget.FrameLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -496,6 +497,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             return@suspendCoroutine
         }
 
+
         createNotificationChannel()
 
         notificationPermissionCallback =
@@ -516,20 +518,22 @@ class SuperwallPaywallActivity : AppCompatActivity() {
     }
 
     private fun createNotificationChannel() {
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel =
-            NotificationChannel(
-                NOTIFICATION_CHANNEL_ID,
-                NOTIFICATION_CHANNEL_NAME,
-                importance,
-            ).apply {
-                description = NOTIFICATION_CHANNEL_DESCRIPTION
-            }
-        channel.setShowBadge(false)
-        // Register the channel with the system
-        val notificationManager: NotificationManager =
-            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(channel)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel =
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    NOTIFICATION_CHANNEL_NAME,
+                    importance,
+                ).apply {
+                    description = NOTIFICATION_CHANNEL_DESCRIPTION
+                }
+            channel.setShowBadge(false)
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
     }
 
     private fun checkAndRequestNotificationPermissions(
@@ -568,9 +572,11 @@ class SuperwallPaywallActivity : AppCompatActivity() {
     private fun areNotificationsEnabled(context: Context): Boolean {
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channel = notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID)
-        if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
-            return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID)
+            if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
+                return false
+            }
         }
         return NotificationManagerCompat.from(context).areNotificationsEnabled()
     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebviewClient.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/DefaultWebviewClient.kt
@@ -1,6 +1,7 @@
 package com.superwall.sdk.paywall.vc.web_view
 
 import android.graphics.Bitmap
+import android.os.Build
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -72,11 +73,19 @@ internal open class DefaultWebviewClient(
         ioScope.launch {
             webviewClientEvents.emit(
                 WebviewClientEvent.OnError(
-                    WebviewError.NetworkError(
-                        error.errorCode,
-                        error.description.toString(),
-                        forUrl,
-                    ),
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        WebviewError.NetworkError(
+                            error.errorCode,
+                            error.description.toString(),
+                            forUrl,
+                        )
+                    } else {
+                        WebviewError.NetworkError(
+                            -1,
+                            "Error description unavailable, Android API version < 23",
+                            forUrl,
+                        )
+                    }
                 ),
             )
         }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.paywall.vc.web_view.messaging
 
 import TemplateLogic
-import android.net.Uri
+import android.util.Base64
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import com.superwall.sdk.Superwall
@@ -29,7 +29,6 @@ import kotlinx.serialization.json.Json
 import org.json.JSONObject
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.util.Base64
 import java.util.Date
 import java.util.LinkedList
 import java.util.Queue
@@ -187,7 +186,7 @@ class PaywallMessageHandler(
 
         // Encode the JSON string to Base64
         val base64Event =
-            encoder.encodeToString(jsonString.toByteArray(StandardCharsets.UTF_8))
+            Base64.encodeToString(jsonString.toByteArray(StandardCharsets.UTF_8), Base64.DEFAULT)
 
         passMessageToWebView(base64String = base64Event)
     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
@@ -7,14 +7,11 @@ import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.paywall.vc.web_view.templating.models.FreeTrialTemplate
 import com.superwall.sdk.paywall.vc.web_view.templating.models.JsonVariables
 import com.superwall.sdk.paywall.view_controller.web_view.templating.models.ProductTemplate
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.util.*
 
 object TemplateLogic {
     suspend fun getBase64EncodedTemplates(
         json: Json,
-        base64: Base64.Encoder,
         paywall: Paywall,
         event: EventData?,
         factory: VariablesFactory,
@@ -59,7 +56,7 @@ object TemplateLogic {
             "!!! Template Logic: $templatesString",
         )
 
-        return base64.encodeToString(templatesData)
+        return android.util.Base64.encodeToString(templatesData, android.util.Base64.DEFAULT)
     }
 
 //    private fun swProductTemplate(

--- a/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.storage.core_data
 
 import android.content.Context
-import android.icu.util.Calendar
+import java.util.Calendar
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -8,7 +8,7 @@ import com.superwall.sdk.utilities.dateFormat
 import kotlinx.serialization.Transient
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.time.Period
+import org.threeten.bp.Period
 import java.util.Calendar
 import java.util.Currency
 import java.util.Locale

--- a/superwall/src/test/java/com/superwall/sdk/contrib/AmountFormatsTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/contrib/AmountFormatsTest.kt
@@ -1,0 +1,215 @@
+package com.superwall.sdk.contrib
+
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import com.superwall.sdk.contrib.threeteen.AmountFormats
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.threeten.bp.Duration
+import org.threeten.bp.Period
+import org.threeten.bp.format.DateTimeParseException
+import java.util.*
+
+class AmountFormatsTest {
+
+    @Test
+    fun testIso8601Format() {
+        Given("a period and duration") {
+            val period = Period.of(1, 2, 3)
+            val duration = Duration.ofHours(4).plusMinutes(5).plusSeconds(6)
+
+            When("formatting to ISO-8601") {
+                val result = AmountFormats.iso8601(period, duration)
+
+                Then("it should return the correct ISO-8601 string") {
+                    assertEquals("P1Y2M3DT4H5M6S", result)
+                }
+            }
+        }
+
+        Given("a zero period and non-zero duration") {
+            val period = Period.ZERO
+            val duration = Duration.ofMinutes(30)
+
+            When("formatting to ISO-8601") {
+                val result = AmountFormats.iso8601(period, duration)
+
+                Then("it should return only the duration string") {
+                    assertEquals("PT30M", result)
+                }
+            }
+        }
+
+        Given("a non-zero period and zero duration") {
+            val period = Period.ofMonths(3)
+            val duration = Duration.ZERO
+
+            When("formatting to ISO-8601") {
+                val result = AmountFormats.iso8601(period, duration)
+
+                Then("it should return only the period string") {
+                    assertEquals("P3M", result)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testWordBasedPeriod() {
+        Given("a period with multiple units") {
+            val period = Period.of(2, 3, 15)
+
+            When("formatting to word-based with English locale") {
+                val result = AmountFormats.wordBased(period, Locale.ENGLISH)
+
+                Then("it should return the correct word-based string") {
+                    assertEquals("2 years, 3 months and 15 days", result)
+                }
+            }
+        }
+
+        Given("a period with opposite signs") {
+            val period = Period.of(1, -2, 0)
+
+            When("formatting to word-based") {
+                val result = AmountFormats.wordBased(period, Locale.ENGLISH)
+
+                Then("it should normalize the period") {
+                    assertEquals("10 months", result)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testWordBasedDuration() {
+        Given("a duration with multiple units") {
+            val duration = Duration.ofHours(25).plusMinutes(30).plusSeconds(45).plusMillis(500)
+
+            When("formatting to word-based with English locale") {
+                val result = AmountFormats.wordBased(duration, Locale.ENGLISH)
+
+                Then("it should return the correct word-based string") {
+                    assertEquals("25 hours, 30 minutes, 45 seconds and 500 milliseconds", result)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testWordBasedPeriodAndDuration() {
+        Given("a period and duration with multiple units") {
+            val period = Period.of(1, 2, 3)
+            val duration = Duration.ofHours(4).plusMinutes(5).plusSeconds(6)
+
+            When("formatting to word-based with English locale") {
+                val result = AmountFormats.wordBased(period, duration, Locale.ENGLISH)
+
+                Then("it should return the correct word-based string") {
+                    assertEquals("1 year, 2 months, 3 days, 4 hours, 5 minutes and 6 seconds", result)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testParseUnitBasedDuration() {
+        Given("a valid duration string") {
+            val durationString = "2h45m30s"
+
+            When("parsing the unit-based duration") {
+                val result = AmountFormats.parseUnitBasedDuration(durationString)
+
+                Then("it should return the correct Duration") {
+                    assertEquals(Duration.ofHours(2).plusMinutes(45).plusSeconds(30), result)
+                }
+            }
+        }
+
+        Given("a duration string with a negative value") {
+            val durationString = "-1.5h"
+
+            When("parsing the unit-based duration") {
+                val result = AmountFormats.parseUnitBasedDuration(durationString)
+
+                Then("it should return the correct negative Duration") {
+                    assertEquals(Duration.ofMinutes(-90), result)
+                }
+            }
+        }
+
+        Given("a duration string with mixed units") {
+            val durationString = "2h30m500ms"
+
+            When("parsing the unit-based duration") {
+                val result = AmountFormats.parseUnitBasedDuration(durationString)
+
+                Then("it should return the correct Duration") {
+                    assertEquals(Duration.ofHours(2).plusMinutes(30).plusMillis(500), result)
+                }
+            }
+        }
+
+        Given("an invalid duration string") {
+            val durationString = "2h30x"
+
+            When("parsing the unit-based duration") {
+                Then("it should throw a DateTimeParseException") {
+                    assertThrows(DateTimeParseException::class.java) {
+                        AmountFormats.parseUnitBasedDuration(durationString)
+                    }
+                }
+            }
+        }
+
+        Given("a duration string with an empty value") {
+            val durationString = ""
+
+            When("parsing the unit-based duration") {
+                Then("it should throw a DateTimeParseException") {
+                    assertThrows(DateTimeParseException::class.java) {
+                        AmountFormats.parseUnitBasedDuration(durationString)
+                    }
+                }
+            }
+        }
+
+        Given("a duration string with only a zero") {
+            val durationString = "0"
+
+            When("parsing the unit-based duration") {
+                val result = AmountFormats.parseUnitBasedDuration(durationString)
+
+                Then("it should return Duration.ZERO") {
+                    assertEquals(Duration.ZERO, result)
+                }
+            }
+        }
+
+        Given("a duration string with a very large value") {
+            val durationString = "9223372036854775807ns"
+
+            When("parsing the unit-based duration") {
+                val result = AmountFormats.parseUnitBasedDuration(durationString)
+
+                Then("it should return the correct Duration") {
+                    assertEquals(Duration.ofNanos(9223372036854775807), result)
+                }
+            }
+        }
+
+        Given("a duration string that exceeds the valid range") {
+            val durationString = "9223372036854775808ns"
+
+            When("parsing the unit-based duration") {
+                Then("it should throw a DateTimeParseException") {
+                    assertThrows(DateTimeParseException::class.java) {
+                        AmountFormats.parseUnitBasedDuration(durationString)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/utils.kt
+++ b/superwall/src/test/java/com/superwall/sdk/utils.kt
@@ -1,3 +1,4 @@
+@file:Suppress("ktlint:standard:function-naming")
 package com.superwall.sdk
 
 fun assertTrue(value: Boolean) {
@@ -10,4 +11,57 @@ fun assertFalse(value: Boolean) {
     if (value) {
         throw AssertionError("Expected false, got true")
     }
+}
+
+
+@DslMarker annotation class TestingDSL
+
+class GivenWhenThenScope(
+    val text: MutableList<String>,
+)
+
+@TestingDSL
+inline fun Given(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    val scope = GivenWhenThenScope(mutableListOf("Given $what"))
+    try {
+        block(scope)
+    } catch (e: Throwable) {
+        e.printStackTrace()
+        println(scope.text.joinToString("\n"))
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun <T> GivenWhenThenScope.When(
+    what: String,
+    block: GivenWhenThenScope.() -> T,
+): T {
+    text.add("\tWhen $what")
+    try {
+        return block(this)
+    } catch (e: Throwable) {
+        throw e
+    }
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.Then(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    text.add("\t\tThen $what")
+    block()
+}
+
+@TestingDSL
+inline fun GivenWhenThenScope.And(
+    what: String,
+    block: GivenWhenThenScope.() -> Unit,
+) {
+    text.add("\t\t\tAnd $what")
+    block()
 }


### PR DESCRIPTION
## Changes in this pull request

- Downgrades minSDK version to 22
- Updates all `java.time` usages to `org.threeten.bp` since it's already included
- Fixes webview support checks
- Updates `AmountFormat` and covers it with tests to ensure same results
- Migrates `java.util.Base64` to `android.util.Base64`
- Fixes other relevant lint errors (72 total, phew)

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)