### PR TITLE
Expose configuration status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.2.7
+
+### Enhancements
+- Exposes current configuration status via `Superwall.instance.configurationStatus`
+
 ## 1.2.6
 
 ### Fixes

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import androidx.work.WorkManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.config.models.ConfigState
+import com.superwall.sdk.config.models.ConfigurationStatus
 import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.delegate.SuperwallDelegate
@@ -211,6 +213,23 @@ class Superwall(
      * [setSubscriptionStatus].
      */
     val subscriptionStatus: StateFlow<SubscriptionStatus> get() = _subscriptionStatus
+
+    /**
+     * A property that indicates current configuration state of the SDK.
+     *
+     * This is `ConfigurationStatus.Pending` when the SDK is yet to finish
+     * configuring. Upon successful configuration, it will change to `ConfigurationStatus.Configured`.
+     * On failure, it will change to `ConfigurationStatus.Failed`.
+     */
+    val configurationState: ConfigurationStatus
+        get() =
+            dependencyContainer.configManager.configState.value.let {
+                when (it) {
+                    is ConfigState.Retrieved -> ConfigurationStatus.Configured
+                    is ConfigState.Failed -> ConfigurationStatus.Failed
+                    else -> ConfigurationStatus.Pending
+                }
+            }
 
     companion object {
         /** A variable that is only `true` if ``instance`` is available for use.

--- a/superwall/src/main/java/com/superwall/sdk/config/models/ConfigurationStatus.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/models/ConfigurationStatus.kt
@@ -1,0 +1,17 @@
+package com.superwall.sdk.config.models
+
+/**
+* Derived from ConfigState.kt.
+* Represents the current configuration status of the SDK.
+* Can be one of:
+* - Pending: The configuration process is not yet completed.
+* - Configured: The configuration process completed successfully.
+* - Failed: The configuration process failed.
+* */
+sealed class ConfigurationStatus {
+    object Pending : ConfigurationStatus()
+
+    object Configured : ConfigurationStatus()
+
+    object Failed : ConfigurationStatus()
+}


### PR DESCRIPTION
## Changes in this pull request

- Exposes current configuration status via `Superwall.instance.configurationStatus`

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)