### PR TITLE
Add sync methods and update KDocs

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -24,9 +24,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.Date
 
+/**
+ * Tracks an analytical event by sending it to the server and, for internal Superwall events, the delegate.
+ *
+ * @param event The event you want to track.
+ * @return TrackingResult The result of the tracking operation.
+ */
 suspend fun Superwall.track(event: Trackable): Result<TrackingResult> {
     return withErrorTracking {
         // Wait for the SDK to be fully initialized
@@ -105,6 +112,24 @@ suspend fun Superwall.track(event: Trackable): Result<TrackingResult> {
         )
     }.toResult()
 }
+
+/**
+ * Tracks an analytical event synchronously.
+ * Warning: This blocks the calling thread.
+ * @param event The event you want to track.
+ * @return TrackingResult The result of the tracking operation.
+ */
+fun Superwall.trackSync(event: Trackable): Result<TrackingResult> =
+    runBlocking {
+        track(event)
+    }
+
+/**
+ * Attempts to implicitly trigger a paywall for a given analytical event.
+ *
+ * @param event The tracked event.
+ * @param eventData The event data that could trigger a paywall.
+ */
 
 suspend fun Superwall.handleImplicitTrigger(
     event: Trackable,

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationStyle.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/PaywallPresentationStyle.kt
@@ -14,7 +14,7 @@ enum class PaywallPresentationStyle(
     FULLSCREEN("FULLSCREEN"),
 
     @SerialName("NO_ANIMATION")
-    FULLSCREEN_NO_ANIMATION("NO_ANIMATION"),
+    FULLSCREEN_NO_ANIMATION("FULLSCREEN_NO_ANIMATION"),
 
     @SerialName("PUSH")
     PUSH("PUSH"),

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PublicPresentation.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PublicPresentation.kt
@@ -23,8 +23,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
+/**
+ * Dismisses the presented paywall, if one exists.
+ */
 suspend fun Superwall.dismiss() =
     withContext(Dispatchers.Main) {
         val completionSignal = CompletableDeferred<Unit>()
@@ -40,6 +44,19 @@ suspend fun Superwall.dismiss() =
         completionSignal.await()
     }
 
+/**
+ * Dismisses the presented paywall synchronously, if one exists.
+ * Warning: This blocks the calling thread.
+ */
+fun Superwall.dismissSync() {
+    runBlocking {
+        dismiss()
+    }
+}
+
+/**
+ * Dismisses the presented paywall, if it exists, in order to present a different one.
+ */
 suspend fun Superwall.dismissForNextPaywall() =
     withContext(Dispatchers.Main) {
         val completionSignal = CompletableDeferred<Unit>()
@@ -58,6 +75,37 @@ suspend fun Superwall.dismissForNextPaywall() =
         completionSignal.await()
     }
 
+/**
+ * Dismisses the presented paywall synchronously, if it exists, in order to present a different one.
+ * Warning: This blocks the calling thread.
+ */
+fun Superwall.dismissSyncForNextPaywall() =
+    runBlocking {
+        dismissForNextPaywall()
+    }
+
+/**
+ * Registers an event to access a feature. When the event is added to a campaign on the Superwall dashboard, it can show a paywall.
+ *
+ * This shows a paywall to the user when: An event you provide is added to a campaign on the [Superwall Dashboard](https://superwall.com/dashboard);
+ * the user matches a rule in the campaign; and the user doesn't have an active subscription.
+ *
+ * Before using this method, you'll first need to create a campaign and add the event to the campaign on the [Superwall Dashboard](https://superwall.com/dashboard).
+ *
+ * The paywall shown to the user is determined by the rules defined in the campaign. When a user is assigned a paywall within a rule,
+ * they will continue to see that paywall unless you remove the paywall from the rule or reset assignments to the paywall.
+ *
+ * @param event The name of the event you wish to register.
+ * @param params Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign.
+ *               Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates.
+ *               Arrays and dictionaries as values are not supported at this time, and will be dropped. Defaults to `null`.
+ * @param handler An optional handler whose functions provide status updates for a paywall. Defaults to `null`.
+ * @param feature A completion block containing a feature that you wish to paywall. Access to this block is remotely configurable via the
+ *                [Superwall Dashboard](https://superwall.com/dashboard). If the paywall is set to _Non Gated_, this will be called when
+ *                the paywall is dismissed or if the user is already paying. If the paywall is _Gated_, this will be called only if the user
+ *                is already paying or if they begin paying. If no paywall is configured, this gets called immediately. This will not be called
+ *                in the event of an error, which you can detect via the `handler`.
+ */
 fun Superwall.register(
     event: String,
     params: Map<String, Any>? = null,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/PublicGetPresentationResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/PublicGetPresentationResult.kt
@@ -10,9 +10,23 @@ import com.superwall.sdk.paywall.presentation.internal.PresentationRequestType
 import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
 import com.superwall.sdk.paywall.presentation.result.PresentationResult
 import com.superwall.sdk.utilities.withErrorTracking
+import kotlinx.coroutines.runBlocking
 import java.util.Date
 import java.util.HashMap
 
+/**
+ * Preemptively gets the result of registering an event.
+ *
+ * This helps you determine whether a particular event will present a paywall
+ * in the future.
+ *
+ * Note that this method does not present a paywall. To do that, use
+ * `register(event:params:handler:feature:)`.
+ *
+ * @param event The name of the event you want to register.
+ * @param params Optional parameters you'd like to pass with your event.
+ * @return A [PresentationResult] that indicates the result of registering an event.
+ */
 suspend fun Superwall.getPresentationResult(
     event: String,
     params: Map<String, Any>? = null,
@@ -31,6 +45,32 @@ suspend fun Superwall.getPresentationResult(
             isImplicit = false,
         )
     }.toResult()
+
+/**
+ * Synchronously preemptively gets the result of registering an event.
+ *
+ * This helps you determine whether a particular event will present a paywall
+ * in the future.
+ *
+ * Note that this method does not present a paywall. To do that, use
+ * `register(event:params:handler:feature:)`.
+ *
+ * Warning: This blocks the calling thread.
+ *
+ * @param event The name of the event you want to register.
+ * @param params Optional parameters you'd like to pass with your event.
+ * @return A [PresentationResult] that indicates the result of registering an event.
+ */
+fun Superwall.getPresentationResultSync(
+    event: String,
+    params: Map<String, Any>? = null,
+): Result<PresentationResult> =
+    runBlocking {
+        getPresentationResult(
+            event,
+            params,
+        )
+    }
 
 internal suspend fun Superwall.internallyGetPresentationResult(
     event: Trackable,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/GetPaywallComponents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/GetPaywallComponents.kt
@@ -15,6 +15,7 @@ import com.superwall.sdk.paywall.presentation.internal.operators.waitForEntitlem
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import com.superwall.sdk.utilities.withErrorTracking
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
 
 /**
  * Runs a pipeline of operations to get a paywall to present and associated components.
@@ -81,3 +82,21 @@ internal suspend fun Superwall.confirmAssignment(request: PresentationRequest): 
         }
     }
 }
+
+/**
+ * Synchronously runs a pipeline of operations to get a paywall to present and associated components.
+ *
+ * @param request The presentation request.
+ * @param publisher A `MutableStateFlow` that gets sent `PaywallState` objects.
+ * @return A `PaywallComponents` object that contains objects associated with the
+ * paywall view controller.
+ * @throws PresentationPipelineError object associated with stages of the pipeline.
+ */
+
+fun Superwall.getPaywallComponentsSync(
+    request: PresentationRequest,
+    publisher: MutableSharedFlow<PaywallState>? = null,
+): PaywallComponents =
+    runBlocking {
+        getPaywallComponents(request, publisher)
+    }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/InternalPresentation.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/InternalPresentation.kt
@@ -13,8 +13,15 @@ import kotlinx.coroutines.withContext
 
 typealias PaywallStatePublisher = Flow<PaywallState>
 
+/**
+ * Runs a background task to present a paywall, publishing [PaywallState] objects that provide updates on the lifecycle of the paywall.
+ *
+ * @param request A presentation request of type [PresentationRequest] to feed into a presentation pipeline.
+ * @param publisher A publisher fed into the pipeline that sends state updates.
+ */
+
 @Throws(Throwable::class)
-suspend fun Superwall.internallyPresent(
+internal suspend fun Superwall.internallyPresent(
     request: PresentationRequest,
     publisher: MutableSharedFlow<PaywallState>,
 ) {
@@ -48,7 +55,7 @@ suspend fun Superwall.internallyPresent(
     }
 }
 
-suspend fun Superwall.dismiss(
+internal suspend fun Superwall.dismiss(
     paywallView: PaywallView,
     result: PaywallResult,
     closeReason: PaywallCloseReason = PaywallCloseReason.SystemLogic,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckDebuggerPresentation.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckDebuggerPresentation.kt
@@ -10,6 +10,12 @@ import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import kotlinx.coroutines.flow.MutableSharedFlow
 
+/**
+ * Cancels the state publisher if the debugger is already launched.
+ *
+ * @param request The presentation request.
+ * @param paywallStatePublisher A [MutableSharedFlow] that gets sent [PaywallState] objects.
+ */
 suspend fun Superwall.checkDebuggerPresentation(
     request: PresentationRequest,
     paywallStatePublisher: MutableSharedFlow<PaywallState>?,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckNoPaywallAlreadyPresented.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckNoPaywallAlreadyPresented.kt
@@ -10,7 +10,7 @@ import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import kotlinx.coroutines.flow.MutableSharedFlow
 
-suspend fun Superwall.checkNoPaywallAlreadyPresented(
+internal suspend fun Superwall.checkNoPaywallAlreadyPresented(
     request: PresentationRequest,
     paywallStatePublisher: MutableSharedFlow<PaywallState>,
 ) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/EvaluateRules.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/EvaluateRules.kt
@@ -18,6 +18,13 @@ data class AssignmentPipelineOutput(
     val debugInfo: Map<String, Any>,
 )
 
+/**
+ * Evaluates the rules from the campaign that the event belongs to.
+ *
+ * @param request The presentation request
+ * @return A [RuleEvaluationOutcome] object containing the trigger result,
+ * confirmable assignment, and unsaved occurrence.
+ */
 suspend fun Superwall.evaluateRules(request: PresentationRequest): Result<RuleEvaluationOutcome> {
     val eventData = request.presentationInfo.eventData
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  * @return A data class that contains info for the next operation.
  */
 @Throws(Throwable::class)
-suspend fun Superwall.getExperiment(
+internal suspend fun Superwall.getExperiment(
     request: PresentationRequest,
     rulesOutcome: RuleEvaluationOutcome,
     debugInfo: Map<String, Any>,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -18,7 +18,18 @@ import com.superwall.sdk.paywall.presentation.rule_logic.RuleEvaluationOutcome
 import com.superwall.sdk.paywall.view.PaywallView
 import kotlinx.coroutines.flow.MutableSharedFlow
 
-suspend fun Superwall.getPresenterIfNecessary(
+/**
+ * Checks conditions for whether the paywall can present before accessing a window on
+ * which the paywall can present.
+ *
+ * @param paywallView The [PaywallView] to present.
+ * @param rulesOutcome The output from evaluating rules.
+ * @param request The presentation request.
+ * @param paywallStatePublisher A [MutableSharedFlow] that gets sent [PaywallState] objects.
+ *
+ * @return An [Activity] to present on, or null if presentation is not necessary.
+ */
+internal suspend fun Superwall.getPresenterIfNecessary(
     paywallView: PaywallView,
     rulesOutcome: RuleEvaluationOutcome,
     request: PresentationRequest,
@@ -71,7 +82,7 @@ suspend fun Superwall.getPresenterIfNecessary(
     return currentActivity
 }
 
-suspend fun Superwall.attemptTriggerFire(
+internal suspend fun Superwall.attemptTriggerFire(
     request: PresentationRequest,
     triggerResult: InternalTriggerResult,
 ) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-suspend fun Superwall.logErrors(
+internal suspend fun Superwall.logErrors(
     request: PresentationRequest,
     error: Throwable,
 ) {


### PR DESCRIPTION
## Changes in this pull request

- Adds `*Sync()` version of methods for non-coroutine users that receive callbacks instead of publishers and run synchronously 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)