### PR TITLE
Add confirmAllAssignments method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.3.0
+- Adds `Superwall.instance.confirmAllAssignments()`, which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.
+
+
 ## 1.2.9
 
 ### Fixes

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -833,6 +833,12 @@ sealed class InternalSuperwallEvent(
         override val canImplicitlyTriggerPaywall: Boolean = true
     }
 
+    object ConfirmAllAssignments : InternalSuperwallEvent(SuperwallEvent.ConfirmAllAssignments) {
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()
+    }
+
     internal data class ErrorThrown(
         val message: String,
         val stacktrace: String,

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -384,6 +384,12 @@ sealed class SuperwallEvent {
             get() = "config_fail"
     }
 
+    // When `confirmAllAssignments` is invoked
+    object ConfirmAllAssignments : SuperwallEvent() {
+        override val rawName: String
+            get() = "confirm_all_assignments"
+    }
+
     // When Superwall.instance.reset is called
     object Reset : SuperwallEvent() {
         override val rawName: String

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -48,5 +48,6 @@ enum class SuperwallEvents(
     RestoreComplete("restore_complete"),
     CustomPlacement("custom_placement"),
     ConfigAttributes("config_attributes"),
+    ConfirmAllAssignments("confirm_all_assignments"),
     ConfigFail("config_fail"),
 }

--- a/superwall/src/main/java/com/superwall/sdk/models/assignment/ConfirmedAssignment.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/assignment/ConfirmedAssignment.kt
@@ -1,0 +1,9 @@
+package com.superwall.sdk.models.assignment
+
+import com.superwall.sdk.models.triggers.Experiment
+import com.superwall.sdk.models.triggers.ExperimentID
+
+class ConfirmedAssignment(
+    val experimentId: ExperimentID,
+    val variant: Experiment.Variant,
+)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -62,6 +62,7 @@ suspend fun Superwall.getPresenterIfNecessary(
 
         is PresentationRequestType.GetImplicitPresentationResult,
         is PresentationRequestType.GetPresentationResult,
+        is PresentationRequestType.ConfirmAllAssignments,
         -> return null
         is PresentationRequestType.Presentation -> Unit
         else -> Unit

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/request/PresentationRequest.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/request/PresentationRequest.kt
@@ -11,6 +11,8 @@ import java.lang.ref.WeakReference
 sealed class PresentationRequestType {
     object Presentation : PresentationRequestType()
 
+    object ConfirmAllAssignments : PresentationRequestType()
+
     data class GetPaywall(
         val adapter: PaywallViewDelegateAdapter,
     ) : PresentationRequestType()
@@ -26,6 +28,7 @@ sealed class PresentationRequestType {
                 is GetPaywall -> "getPaywallViewController"
                 is GetPresentationResult -> "getPresentationResult"
                 is GetImplicitPresentationResult -> "getImplicitPresentationResult"
+                is ConfirmAllAssignments -> "confirmAllAssignments"
                 else -> "Unknown"
             }
 
@@ -73,6 +76,7 @@ data class PresentationRequest(
                         is PresentationRequestType.Presentation -> "register"
                         is PresentationRequestType.GetPresentationResult -> null
                         is PresentationRequestType.GetImplicitPresentationResult -> null
+                        is PresentationRequestType.ConfirmAllAssignments -> null
                         else -> null
                     }
             }


### PR DESCRIPTION
## Changes in this pull request

- Adds `Superwall.instance.confirmAllAssignments()`, which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.

##TODO
- Unit tests

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)