### PR TITLE
Ensure missing WebView doesn't cause crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ### Fixes
 
 - Fixes issues with Paywall sometimes not displaying when returning from background 
+- Fixes issue with SDK crashing when WebView is not available
 
 ## 1.2.9
 

--- a/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
@@ -1,7 +1,6 @@
 package com.superwall.sdk.config
 
 import android.content.Context
-import android.webkit.WebView
 import com.superwall.sdk.dependencies.RequestFactory
 import com.superwall.sdk.dependencies.RuleAttributesFactory
 import com.superwall.sdk.models.config.Config
@@ -12,6 +11,7 @@ import com.superwall.sdk.paywall.manager.PaywallManager
 import com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator.ExpressionEvaluator
 import com.superwall.sdk.paywall.presentation.rule_logic.javascript.JavascriptEvaluator
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
+import com.superwall.sdk.paywall.vc.web_view.webViewExists
 import com.superwall.sdk.storage.LocalStorage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -87,8 +87,7 @@ class PaywallPreload(
 
     // Preloads paywalls referenced by triggers.
     private suspend fun preloadPaywalls(paywallIdentifiers: Set<String>) {
-        val webviewExists =
-            WebView.getCurrentWebViewPackage() != null
+        val webviewExists = webViewExists()
 
         if (webviewExists) {
             scope.launch {

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -66,6 +66,7 @@ import com.superwall.sdk.paywall.vc.web_view.SWWebView
 import com.superwall.sdk.paywall.vc.web_view.messaging.PaywallMessageHandler
 import com.superwall.sdk.paywall.vc.web_view.templating.models.JsonVariables
 import com.superwall.sdk.paywall.vc.web_view.templating.models.Variables
+import com.superwall.sdk.paywall.vc.web_view.webViewExists
 import com.superwall.sdk.storage.EventsQueue
 import com.superwall.sdk.storage.LocalStorage
 import com.superwall.sdk.store.InternalPurchaseController
@@ -332,7 +333,9 @@ class DependencyContainer(
          * For more info check https://issuetracker.google.com/issues/245155339
          */
         ioScope.launch {
-            WebSettings.getDefaultUserAgent(context)
+            if (webViewExists()) {
+                WebSettings.getDefaultUserAgent(context)
+            }
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
@@ -1,6 +1,5 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import android.webkit.WebView
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.dependencies.DependencyContainer
@@ -18,6 +17,7 @@ import com.superwall.sdk.paywall.presentation.rule_logic.RuleEvaluationOutcome
 import com.superwall.sdk.paywall.request.PaywallRequest
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.vc.PaywallView
+import com.superwall.sdk.paywall.vc.web_view.webViewExists
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 
@@ -70,7 +70,7 @@ internal suspend fun Superwall.getPaywallView(
                 request.flags.type != PresentationRequestType.GetPresentationResult
         val delegate = request.flags.type.paywallViewDelegateAdapter
 
-        val webviewExists = WebView.getCurrentWebViewPackage() != null
+        val webviewExists = webViewExists()
         if (webviewExists) {
             dependencyContainer.paywallManager.getPaywallView(
                 request = paywallRequest,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/javascript/DefaultJavascriptEvalutor.kt
@@ -10,6 +10,7 @@ import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.triggers.TriggerRule
 import com.superwall.sdk.models.triggers.TriggerRuleOutcome
 import com.superwall.sdk.models.triggers.UnmatchedRule
+import com.superwall.sdk.paywall.vc.web_view.webViewExists
 import com.superwall.sdk.storage.LocalStorage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -73,7 +74,7 @@ class DefaultJavascriptEvalutor(
     private suspend fun createNewEvaluator(context: Context): JavascriptEvaluator =
         when {
             JavaScriptSandbox.isSupported() -> createSandboxEvaluator(context)
-            WebView.getCurrentWebViewPackage() != null -> createWebViewEvaluator(context)
+            webViewExists() -> createWebViewEvaluator(context)
             else -> NoSupportedEvaluator
         }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -267,3 +267,10 @@ class SWWebView(
         )
     }
 }
+
+internal fun webViewExists(): Boolean =
+    try {
+        WebView.getCurrentWebViewPackage() != null
+    } catch (e: Throwable) {
+        false
+    }


### PR DESCRIPTION

## Changes in this pull request

- Ensures a missing WebView on the users device doesn't cause a crash

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)