### PR TITLE
Return result in getPaywall, deprecate old method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.3.0
 
+### Enhancements
+- The existing `getPaywall` method has been deprecated and renamed to `getPaywallOrThrow`. The new `getPaywall` method now returns a `kotlin.Result<PaywallView>` instead of throwing an exception.
+
 ### Fixes
 
 - Fixes issues with Paywall sometimes not displaying when returning from background 
 - Fixes issue with SDK crashing when WebView is not available
+- Update visibility of internal `getPaywall` methods to `internal` to prevent misuse
 
 ## 1.2.9
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/InternalGetPaywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/InternalGetPaywall.kt
@@ -21,7 +21,7 @@ data class PaywallComponents(
 }
 
 @Throws(Throwable::class)
-suspend fun Superwall.getPaywall(
+internal suspend fun Superwall.getPaywall(
     request: PresentationRequest,
     publisher: MutableSharedFlow<PaywallState> = MutableSharedFlow(),
 ): PaywallView =


### PR DESCRIPTION
## Changes in this pull request

### Enhancements
- The existing `getPaywall` method has been deprecated and renamed to `getPaywallOrThrow`. The new `getPaywall` method now returns a `kotlin.Result<PaywallView>` instead of throwing an exception.

### Fixes
- Update visibility of internal `getPaywall` methods to `internal` to prevent misuse

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)