### PR TITLE
Fix unsanitized cache file pointers and ensure folder existance

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/CacheKeys.kt
@@ -51,7 +51,15 @@ interface Storable<T> {
     val directory: SearchPathDirectory
     val serializer: KSerializer<T>
 
-    fun path(context: Context): String = directory.fileDirectory(context).absolutePath + File.separator + key.toMD5()
+    fun file(context: Context): File =
+        File(
+            directory.fileDirectory(context).also {
+                if (!it.exists()) {
+                    it.mkdir()
+                }
+            },
+            key.toMD5(),
+        )
 }
 
 fun String.toMD5(): String {


### PR DESCRIPTION
## Changes in this pull request

- Fixes cache folder using unsupported paths in API level <28 by creating a file directly instead of creating it from the generated path.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)