### PR TITLE
Fix background restoration issues and ensure safety of destroy calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.3.1
+
+### Fixes
+- Fixes issue when destroying activities during sleep would cause a background crash
+
 ## 1.3.0
 
 ### Enhancements

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -424,7 +424,6 @@ class SuperwallPaywallActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         val content = contentView as? ViewGroup?
         if (content != null && content is CoordinatorLayout) {
             val bottomSheetBehavior = BottomSheetBehavior.from(content.getChildAt(0))
@@ -434,11 +433,19 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         }
         val pv = intent.getStringExtra(VIEW_KEY)
         if (pv != null) {
-            (
-                Superwall.instance.dependencyContainer
-                    .makeViewStore()
-                    .retrieveView(pv) as PaywallView
-            ).cleanup()
+            try {
+                (
+                    Superwall.instance.dependencyContainer
+                        .makeViewStore()
+                        .retrieveView(pv) as? PaywallView?
+                )?.cleanup()
+            } catch (e: Throwable) {
+                Logger.debug(
+                    LogLevel.debug,
+                    LogScope.paywallView,
+                    "Cache cleanup failed - application going to sleep.",
+                )
+            }
         }
         paywallView()?.webView?.onScrollChangeListener = null
         paywallView()?.cleanup()
@@ -447,6 +454,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         (paywallView() as? ActivityEncapsulatable)?.encapsulatingActivity = null
         // Clear the reference to the contentView
         contentView = null
+        super.onDestroy()
     }
 
     //region Notifications


### PR DESCRIPTION
## Changes in this pull request

- Fixes issue when destroying activities during sleep would cause a background crash

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)