### PR TITLE
Move super.onCreate after requesting window features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ### Fixes
 - Fixes issue when destroying activities during sleep would cause a background crash
+- Fixes issue when using Superwall with some SDK's would cause a crash (i.e. Smartlook SDK)
 
 ## 1.3.0
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -123,8 +123,6 @@ class SuperwallPaywallActivity : AppCompatActivity() {
     private fun paywallView(): PaywallView? = contentView?.findViewWithTag(ACTIVE_PAYWALL_TAG)
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         val presentationStyle =
             intent.getSerializableExtra(PRESENTATION_STYLE_KEY) as? PaywallPresentationStyle
@@ -149,6 +147,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         }
 
         requestWindowFeature(Window.FEATURE_NO_TITLE)
+        super.onCreate(savedInstanceState)
 
         val key = intent.getStringExtra(VIEW_KEY)
         if (key == null) {


### PR DESCRIPTION

## Changes in this pull request

- Fixes issue when using Superwall with some SDK's would cause a crash (i.e. Smartlook SDK)

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)