### PR TITLE
Fix issues with trialDays by checking lower values first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.4.0-beta.2
+
+- Fixes issue with `trialPeriodDays` rounding to the higher value instead of lower, i.e. where `P4W2D` would return 28 days instead of 30, it now returns 30.
+
 ## 1.4.0-beta.1
 
 - Updates methods to return `kotlin.Result` instead of relying on throwing exceptions

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -53,14 +53,14 @@ data class SubscriptionPeriod(
             val days = (totalDays % 7).toInt()
 
             return when {
-                period.years > 0 -> SubscriptionPeriod(period.years, Unit.year)
+                days > 0 -> SubscriptionPeriod(totalDays, Unit.day)
+                weeks > 0 -> SubscriptionPeriod(weeks, Unit.week)
                 period.toTotalMonths() > 0 ->
                     SubscriptionPeriod(
                         period.toTotalMonths().toInt(),
                         Unit.month,
                     )
-                weeks > 0 -> SubscriptionPeriod(weeks, Unit.week)
-                days > 0 -> SubscriptionPeriod(days, Unit.day)
+                period.years > 0 -> SubscriptionPeriod(period.years, Unit.year)
                 else -> null
             }?.normalized()
         }

--- a/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.store.abstractions.product
 
+import org.junit.Test
 import java.math.BigDecimal
 
 /**
@@ -22,6 +23,13 @@ fun truncateDecimal(
 }
 
 class SubscriptionPeriodUnitTest {
+    @Test
+    fun double_period_test() {
+        val period = "P4W2D"
+        val res = SubscriptionPeriod.from(period)
+        println(res)
+        assert(res == SubscriptionPeriod(30, SubscriptionPeriod.Unit.day))
+    }
 /* TODO: Re-enable these in CI
     @Test
     fun singleDaily_isCorrect() {


### PR DESCRIPTION
## Changes in this pull request

- Fixes issue with `trialPeriodDays` rounding to the higher value instead of lower, i.e. where `P4W2D` would return 28 days instead of 30, it now returns 30.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)