### PR TITLE
Improve single thread usage, allocations, render priorities and scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 1.4.0
+
+## Enhancements
+
+- Improves paywall loading and preloading performance
+- Reduces impact of preloading on render performance
+- Updates methods to return `kotlin.Result` instead of relying on throwing exceptions
+- This introduces some minor breaking changes:
+  - `configure` completion block now provides a `Result<Unit>` that can be used to check for success or failure
+  - `handleDeepLink` now returns a `Result<Boolean>`
+  - `getAssignments` now returns a `Result<List<ConfirmedAssignments>>`
+  - `confirmAllAssignments` now returns a `Result<List<ConfirmedAssignments>>`
+  - `getPresentationResult` now returns a `Result<PresentationResult>`
+  - `getPaywallComponents` now returns a `Result<PaywallComponents>`
+- Removes Gson dependency
+- Adds `isScrollEnabled` flag to enable remote controll of Paywall scrollability
+
+## Fixes
+- Fixes issue where paywalls without fallback would fail to load and missing resource would cause a failure event
+- Fixes issue with `trialPeriodDays` rounding to the higher value instead of lower, i.e. where `P4W2D` would return 28 days instead of 30, it now returns 30.
+- Fixes issue with system navigation bar not respecting paywall color
+- Fixes issues with cursor allocation in Room transaction
+
+
 ## 1.4.0-beta.3
 
 - Fixes issue where paywalls without fallback would fail to load and missing resource would cause a failure event

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,11 +30,12 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {

--- a/superwall/proguard-rules.pro
+++ b/superwall/proguard-rules.pro
@@ -7,10 +7,9 @@
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keepclassmembers class com.superwall.sdk.paywall.vc.web_view.messaging.PaywallMessageHandler {
+   public *;
+}
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
@@ -23,3 +22,44 @@
 -keep class com.superwall.** { *; }
 -keep class androidx.lifecycle.DefaultLifecycleObserver
 -keep public class * implements java.lang.reflect.Type
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep @kotlinx.serialization.Serializable class *
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Don't print notes about potential mistakes or omissions in the configuration for kotlinx-serialization classes
+# See also https://github.com/Kotlin/kotlinx.serialization/issues/1900
+-dontnote kotlinx.serialization.**
+
+# Serialization core uses `java.lang.ClassValue` for caching inside these specified classes.
+# If there is no `java.lang.ClassValue` (for example, in Android), then R8/ProGuard will print a warning.
+# However, since in this case they will not be used, we can disable these warnings
+-dontwarn kotlinx.serialization.internal.ClassValueReferences
+
+# disable optimisation for descriptor field because in some versions of ProGuard, optimization generates incorrect bytecode that causes a verification error
+# see https://github.com/Kotlin/kotlinx.serialization/issues/2719
+-keepclassmembers public class **$$serializer {
+    private ** descriptor;
+}

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -38,7 +38,7 @@ sealed class TrackingLogic {
             trackableEvent: Trackable,
             appSessionId: String,
         ): TrackingParameters =
-            withContext(Dispatchers.Default) {
+            withContext(Dispatchers.IO) {
                 val superwallParameters = trackableEvent.getSuperwallParameters().toMutableMap()
                 superwallParameters["app_session_id"] = appSessionId
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -190,7 +190,7 @@ class DependencyContainer(
         storeKitManager = StoreKitManager(context, purchaseController, googleBillingWrapper)
 
         delegateAdapter = SuperwallDelegateAdapter()
-        storage = LocalStorage(context = context, factory = this, json = json())
+        storage = LocalStorage(context = context, ioScope = ioScope(), factory = this, json = json())
         val httpConnection =
             CustomHttpUrlConnection(
                 json = json(),
@@ -286,7 +286,14 @@ class DependencyContainer(
                 },
             )
 
-        eventsQueue = EventsQueue(context, configManager = configManager, network = network)
+        eventsQueue =
+            EventsQueue(
+                context,
+                configManager = configManager,
+                network = network,
+                ioScope = ioScope(),
+                mainScope = mainScope(),
+            )
 
         identityManager =
             IdentityManager(
@@ -406,6 +413,7 @@ class DependencyContainer(
                 ioScope = ioScope,
                 encoder = encoder,
                 json = paywallJson,
+                mainScope = mainScope(),
             )
 
         val paywallView =

--- a/superwall/src/main/java/com/superwall/sdk/misc/SerialTaskManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/SerialTaskManager.kt
@@ -6,7 +6,7 @@ import java.util.LinkedList
 import java.util.Queue
 
 class SerialTaskManager(
-    private val coroutineScope: CoroutineScope = CoroutineScope(newSingleThreadContext("SerialTaskManager")),
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1)),
 ) {
     private val taskQueue: Queue<suspend () -> Unit> = LinkedList()
     private var currentTask: Deferred<Unit>? = null

--- a/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
@@ -1,6 +1,7 @@
 package com.superwall.sdk.network.device
 
 import com.superwall.sdk.analytics.superwall.SuperwallEvents
+import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -8,6 +9,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 
 @Serializable
+@Polymorphic
 internal sealed class Capability(
     @SerialName("name")
     val name: String,

--- a/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/Capability.kt
@@ -4,6 +4,7 @@ import com.superwall.sdk.analytics.superwall.SuperwallEvents
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.encodeToJsonElement
@@ -43,6 +44,10 @@ internal sealed class Capability(
     object ConfigCaching : Capability("config_caching")
 }
 
-internal fun List<Capability>.toJson(json: Json): JsonElement = json.encodeToJsonElement(this)
+internal fun List<Capability>.toJson(json: Json): JsonElement =
+    json.encodeToJsonElement(
+        ListSerializer(Capability.serializer()),
+        this,
+    )
 
 internal fun List<Capability>.namesCommaSeparated(): String = this.joinToString(",") { it.name }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -15,6 +15,7 @@ import com.superwall.sdk.models.product.Product
 import com.superwall.sdk.models.product.ProductItem
 import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.store.abstractions.product.StoreProduct
+import com.superwall.sdk.utilities.DateFormatterUtil
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.util.Date
@@ -112,27 +113,54 @@ data class PaywallInfo(
         featureGatingBehavior = featureGatingBehavior,
         presentedBy = eventData?.let { "event" } ?: "programmatically",
         presentationSourceType = presentationSourceType,
-        responseLoadStartTime = responseLoadStartTime?.toString() ?: "",
-        responseLoadCompleteTime = responseLoadStartTime?.toString() ?: "",
-        responseLoadFailTime = responseLoadFailTime?.toString() ?: "",
+        responseLoadStartTime =
+            responseLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        responseLoadCompleteTime =
+            responseLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        responseLoadFailTime =
+            responseLoadFailTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
         responseLoadDuration =
             responseLoadStartTime?.let { startTime ->
                 responseLoadCompleteTime?.let { endTime ->
                     (endTime.time / 1000 - startTime.time / 1000).toDouble()
                 }
             },
-        webViewLoadStartTime = webViewLoadStartTime?.toString() ?: "",
-        webViewLoadCompleteTime = webViewLoadCompleteTime?.toString() ?: "",
-        webViewLoadFailTime = webViewLoadFailTime?.toString() ?: "",
+        webViewLoadStartTime =
+            webViewLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        webViewLoadCompleteTime =
+            webViewLoadCompleteTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        webViewLoadFailTime =
+            webViewLoadFailTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
         webViewLoadDuration =
             webViewLoadStartTime?.let { startTime ->
                 webViewLoadCompleteTime?.let { endTime ->
                     (endTime.time / 1000 - startTime.time / 1000).toDouble()
                 }
             },
-        productsLoadStartTime = productsLoadStartTime?.toString() ?: "",
-        productsLoadCompleteTime = productsLoadCompleteTime?.toString() ?: "",
-        productsLoadFailTime = productsLoadFailTime?.toString() ?: "",
+        productsLoadStartTime =
+            productsLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        productsLoadCompleteTime =
+            productsLoadCompleteTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        productsLoadFailTime =
+            productsLoadFailTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
         productsLoadDuration =
             productsLoadStartTime?.let { startTime ->
                 productsLoadCompleteTime?.let { endTime ->

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallView.kt
@@ -10,6 +10,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebSettings
+import android.webkit.WebView.RENDERER_PRIORITY_IMPORTANT
 import android.widget.FrameLayout
 import androidx.browser.customtabs.CustomTabsIntent
 import com.superwall.sdk.Superwall
@@ -82,6 +83,17 @@ class PaywallView(
     SWWebViewDelegate,
     ActivityEncapsulatable,
     GameControllerDelegate {
+    private companion object {
+        private val mainScope: MainScope = MainScope()
+        private val ioScope: IOScope = IOScope()
+        private val gameControllerJson by lazy {
+            Json {
+                encodeDefaults = true
+                namingStrategy = JsonNamingStrategy.SnakeCase
+            }
+        }
+    }
+
     interface Factory : TriggerFactory
     //region Public properties
 
@@ -185,14 +197,6 @@ class PaywallView(
     //endregion
 
     //region Initialization
-    private val mainScope: MainScope = MainScope()
-    private val ioScope: IOScope = IOScope()
-    private val gameControllerJson by lazy {
-        Json {
-            encodeDefaults = true
-            namingStrategy = JsonNamingStrategy.SnakeCase
-        }
-    }
 
     init {
         id = View.generateViewId()
@@ -299,6 +303,7 @@ class PaywallView(
 
         Superwall.instance.dependencyContainer.delegateAdapter
             .willPresentPaywall(info)
+        webView.setRendererPriorityPolicy(RENDERER_PRIORITY_IMPORTANT, true)
         webView.scrollTo(0, 0)
         if (loadingState is PaywallLoadingState.Ready) {
             webView.messageHandler.handle(PaywallMessage.TemplateParamsAndUserAttributes)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/SuperwallPaywallActivity.kt
@@ -81,6 +81,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             // We force this in main scope in case the user started it from a non-main thread
             CoroutineScope(Dispatchers.Main).launch {
                 if (view.webView.parent == null) {
+                    view.webView.enableOffscreenRender()
                     view.addView(view.webView)
                 }
                 val viewStorageViewModel = Superwall.instance.dependencyContainer.makeViewStore()

--- a/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
@@ -8,15 +8,15 @@ import com.superwall.sdk.storage.memory.LRUCache
 import com.superwall.sdk.storage.memory.PerpetualCache
 import com.superwall.sdk.utilities.withErrorTracking
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.CoroutineContext
 
 class Cache(
     val context: Context,
-    private val ioQueue: ExecutorCoroutineDispatcher = newSingleThreadContext(Cache.ioQueuePrefix),
+    private val ioQueue: CoroutineContext = Dispatchers.IO.limitedParallelism(1),
     private val json: Json,
 ) : CoroutineScope by CoroutineScope(ioQueue) {
     companion object {

--- a/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
@@ -11,22 +11,23 @@ import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
 import com.superwall.sdk.storage.core_data.entities.ManagedEventData
 import com.superwall.sdk.storage.core_data.entities.ManagedTriggerRuleOccurrence
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
 import java.util.Date
+import kotlin.coroutines.CoroutineContext
 
 // TODO: https://linear.app/superwall/issue/SW-2346/[android]-coredatamanager-implementation
 class CoreDataManager(
     context: Context,
-) {
-    private val queue = newSingleThreadContext("com.superwall.coredatamanager")
+) : CoroutineScope {
+    override val coroutineContext: CoroutineContext = Dispatchers.IO.limitedParallelism(1)
     private val superwallDatabase by lazy { SuperwallDatabase.getDatabase(context = context) }
 
     fun saveEventData(
         eventData: EventData,
         completion: ((ManagedEventData) -> Unit)? = null,
     ) {
-        CoroutineScope(queue).launch {
+        launch {
             try {
                 // Create a new EventData object
                 val managedEventData =
@@ -57,7 +58,7 @@ class CoreDataManager(
         triggerRuleOccurrence: TriggerRuleOccurrence,
         completion: ((ManagedTriggerRuleOccurrence) -> Unit)? = null,
     ) {
-        CoroutineScope(queue).launch {
+        launch {
             try {
                 val managedRuleOccurrence =
                     ManagedTriggerRuleOccurrence(
@@ -80,7 +81,7 @@ class CoreDataManager(
     }
 
     fun deleteAllEntities() {
-        CoroutineScope(queue).launch {
+        launch {
             try {
                 superwallDatabase.managedTriggerRuleOccurrenceDao().deleteAll()
                 superwallDatabase.managedEventDataDao().deleteAll()

--- a/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
@@ -13,4 +13,6 @@ internal object DateUtils {
     val MMM_dd_yyyy = "MMM dd, yyyy"
 }
 
-internal fun dateFormat(format: String) = SimpleDateFormat(format, Locale.US)
+internal fun dateFormat(format: String = DateUtils.ISO_MILLIS) = SimpleDateFormat(format, Locale.US)
+
+internal val DateFormatterUtil = dateFormat()

--- a/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
@@ -3,9 +3,11 @@ package com.superwall.sdk.utilities
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.billing.BillingError
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.Either
 import com.superwall.sdk.network.NetworkError
+import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationPipelineError
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallSkippedReason
 import com.superwall.sdk.storage.ErrorLog
@@ -120,4 +122,6 @@ private fun Throwable.shouldLog() =
         this !is PresentationPipelineError &&
         this !is TransactionError &&
         this !is PaywallSkippedReason &&
-        (this is NetworkError.Decoding || this !is NetworkError)
+        (this is NetworkError.Decoding || this !is NetworkError) &&
+        this !is BillingError ||
+        this !is PaywallPresentationRequestStatusReason


### PR DESCRIPTION
## Changes in this pull request

- Replaces usages of `singleThreadContext` with `limitedParallelism` to reduce memory footprint
- Reuses often allocated objects
- Enables render priority for to-be-presented paywalls
- Replaces scope instantiation with scope reuse
- Other minor changes

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)