### PR TITLE
Add events flowable, allowing users to listen to superwall events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.5.0-beta.1
+
+## Enhancements
+- Adds `Superwall.instance.events` - A SharedFlow instance emitting all Superwall events as `SuperwallEventInfo`. This can be used as an alternative to a delegate for listening to events.
 
 ## 1.4.1
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.work.WorkManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.config.models.ConfigState
 import com.superwall.sdk.config.models.ConfigurationStatus
 import com.superwall.sdk.config.options.SuperwallOptions
@@ -53,8 +54,11 @@ import com.superwall.sdk.utilities.withErrorTracking
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
@@ -82,6 +86,16 @@ class Superwall(
     private var purchaseTask: Job? = null
 
     internal val presentationItems: PresentationItems = PresentationItems()
+
+    private val _events: MutableSharedFlow<SuperwallEventInfo> =
+        MutableSharedFlow(0, extraBufferCapacity = 64 * 4, onBufferOverflow = BufferOverflow.SUSPEND)
+
+    /**
+     * A flow emitting all Superwall events as an alternative to delegate.
+     * @see SuperwallEventInfo for more information and possible events
+     * */
+
+    val events: SharedFlow<SuperwallEventInfo> = _events
 
     var localeIdentifier: String?
         get() = dependencyContainer.configManager.options.localeIdentifier
@@ -145,6 +159,12 @@ class Superwall(
             ioScope.launch {
                 track(dependencyContainer.makeConfigAttributes())
             }
+        }
+    }
+
+    internal fun emitSuperwallEvent(info: SuperwallEventInfo) {
+        ioScope.launch {
+            _events.emit(info)
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -50,6 +50,7 @@ suspend fun Superwall.track(event: Trackable): Result<TrackingResult> {
                 )
 
             dependencyContainer.delegateAdapter.handleSuperwallEvent(eventInfo = info)
+            emitSuperwallEvent(info)
 
             Logger.debug(
                 logLevel = LogLevel.debug,


### PR DESCRIPTION
## Changes in this pull request

- Adds `Superwall.instance.events` - A SharedFlow instance emitting all Superwall events as `SuperwallEventInfo`. This can be used as an alternative to a delegate for listening to events.


### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)