### PR TITLE
Add shimmer time tracking events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.5.0-beta.2
+
+## Enhancements
+- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
+
 ## 1.5.0-beta.1
 
 ## Enhancements

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -107,6 +107,10 @@ sealed class TrackingLogic {
                 }
             }
 
+            if (event is InternalSuperwallEvent.ShimmerLoad) {
+                return !disableVerboseEvents
+            }
+
             (event as? InternalSuperwallEvent.PaywallProductsLoad)?.let {
                 return when (it.state) {
                     is InternalSuperwallEvent.PaywallProductsLoad.State.Start,

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -843,6 +843,41 @@ sealed class InternalSuperwallEvent(
         override val canImplicitlyTriggerPaywall: Boolean = true
     }
 
+    data class ShimmerLoad(
+        val state: State,
+        val paywallId: String,
+        val visibleDuration: Double?,
+        val delay: Double,
+        val preloadingEnabled: Boolean,
+    ) : InternalSuperwallEvent(
+            if (state ==
+                State.Started
+            ) {
+                SuperwallEvent.ShimmerViewStart
+            } else {
+                SuperwallEvent.ShimmerViewComplete(visibleDuration ?: 0.0)
+            },
+        ) {
+        enum class State {
+            Started,
+            Complete,
+        }
+
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
+
+        override val rawName: String
+            get() = superwallEvent.rawName
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> =
+            mapOf(
+                "paywall_id" to paywallId,
+                "preloading_enabled" to preloadingEnabled,
+                "visible_duration" to visibleDuration,
+            ).filter { it.value != null }.toMap() as Map<String, Any>
+
+        override val canImplicitlyTriggerPaywall: Boolean = false
+    }
+
     object ConfirmAllAssignments : InternalSuperwallEvent(SuperwallEvent.ConfirmAllAssignments) {
         override val audienceFilterParams: Map<String, Any> = emptyMap()
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -416,6 +416,18 @@ sealed class SuperwallEvent {
         override val rawName: String = SuperwallEvents.CustomPlacement.rawName
     }
 
+    data object ShimmerViewStart : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.ShimmerViewStart.rawName
+    }
+
+    data class ShimmerViewComplete(
+        val duration: Double,
+    ) : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.ShimmerViewComplete.rawName
+    }
+
     internal object ErrorThrown : SuperwallEvent(), IsInternalEvent {
         override val rawName: String
             get() = "error_thrown"

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -48,6 +48,8 @@ enum class SuperwallEvents(
     RestoreFail("restore_fail"),
     RestoreComplete("restore_complete"),
     CustomPlacement("custom_placement"),
+    ShimmerViewStart("shimmerView_start"),
+    ShimmerViewComplete("shimmerView_complete"),
     ConfigAttributes("config_attributes"),
     ConfirmAllAssignments("confirm_all_assignments"),
     ConfigFail("config_fail"),

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -643,7 +643,7 @@ class DependencyContainer(
 
     override fun makeTransactionVerifier(): GoogleBillingWrapper = googleBillingWrapper
 
-    override suspend fun makeSuperwallOptions(): SuperwallOptions = configManager.options
+    override fun makeSuperwallOptions(): SuperwallOptions = configManager.options
 
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -184,7 +184,7 @@ interface StoreTransactionFactory {
 }
 
 interface OptionsFactory {
-    suspend fun makeSuperwallOptions(): SuperwallOptions
+    fun makeSuperwallOptions(): SuperwallOptions
 }
 
 interface TriggerFactory {

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -85,6 +85,8 @@ data class Paywall(
     var webviewLoadingInfo: LoadingInfo = LoadingInfo(),
     @kotlinx.serialization.Transient()
     var productsLoadingInfo: LoadingInfo = LoadingInfo(),
+    @kotlinx.serialization.Transient()
+    var shimmerLoadingInfo: LoadingInfo = LoadingInfo(),
     var productVariables: List<ProductVariable>? = null,
     var swProductVariablesTemplate: List<ProductVariable>? = null,
     var paywalljsVersion: String? = null,
@@ -209,6 +211,8 @@ data class Paywall(
             productsLoadStartTime = productsLoadingInfo.startAt,
             productsLoadFailTime = productsLoadingInfo.failAt,
             productsLoadCompleteTime = productsLoadingInfo.endAt,
+            shimmerLoadStartTime = shimmerLoadingInfo.startAt,
+            shimmerLoadCompleteTime = shimmerLoadingInfo.endAt,
             experiment = experiment,
             paywalljsVersion = paywalljsVersion,
             isFreeTrialAvailable = isFreeTrialAvailable,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -52,6 +52,8 @@ data class PaywallInfo(
     val productsLoadStartTime: String?,
     val productsLoadCompleteTime: String?,
     val productsLoadFailTime: String?,
+    val shimmerLoadStartTime: String?,
+    val shimmerLoadCompleteTime: String?,
     val productsLoadDuration: Double?,
     val paywalljsVersion: String?,
     val isFreeTrialAvailable: Boolean,
@@ -83,6 +85,8 @@ data class PaywallInfo(
         productsLoadStartTime: Date?,
         productsLoadFailTime: Date?,
         productsLoadCompleteTime: Date?,
+        shimmerLoadStartTime: Date?,
+        shimmerLoadCompleteTime: Date?,
         experiment: Experiment? = null,
         paywalljsVersion: String? = null,
         isFreeTrialAvailable: Boolean,
@@ -167,6 +171,14 @@ data class PaywallInfo(
                     (endTime.time / 1000 - startTime.time / 1000).toDouble()
                 }
             },
+        shimmerLoadStartTime =
+            webViewLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        shimmerLoadCompleteTime =
+            webViewLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
         localNotifications = localNotifications,
         computedPropertyRequests = computedPropertyRequests,
         closeReason = closeReason,


### PR DESCRIPTION
## Changes in this pull request

- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)