### PR TITLE
1.5.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## Enhancements
 - Adds `Superwall.instance.events` - A SharedFlow instance emitting all Superwall events as `SuperwallEventInfo`. This can be used as an alternative to a delegate for listening to events.
 - Adds a new shimmer animation
+- Adds support for SuperScript expression evaluator
 
 ## 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.5.0-beta.2
+
+## Enhancements
+- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
+
 ## 1.5.0-beta.1
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## Enhancements
 - Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
+- Makes `hasFreeTrial` match iOS SDK behavior by returning `true` for both free trials and non-free introductory offers
 
 ## 1.5.0-beta.1
 

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "1.4.1"
+version = "1.5.0-beta.1"
 
 android {
     compileSdk = 34

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "1.5.0-beta.1"
+version = "1.5.0-beta.2"
 
 android {
     compileSdk = 34

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -107,6 +107,10 @@ sealed class TrackingLogic {
                 }
             }
 
+            if (event is InternalSuperwallEvent.ShimmerLoad) {
+                return !disableVerboseEvents
+            }
+
             (event as? InternalSuperwallEvent.PaywallProductsLoad)?.let {
                 return when (it.state) {
                     is InternalSuperwallEvent.PaywallProductsLoad.State.Start,

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -843,6 +843,41 @@ sealed class InternalSuperwallEvent(
         override val canImplicitlyTriggerPaywall: Boolean = true
     }
 
+    data class ShimmerLoad(
+        val state: State,
+        val paywallId: String,
+        val visibleDuration: Double?,
+        val delay: Double,
+        val preloadingEnabled: Boolean,
+    ) : InternalSuperwallEvent(
+            if (state ==
+                State.Started
+            ) {
+                SuperwallEvent.ShimmerViewStart
+            } else {
+                SuperwallEvent.ShimmerViewComplete(visibleDuration ?: 0.0)
+            },
+        ) {
+        enum class State {
+            Started,
+            Complete,
+        }
+
+        override val audienceFilterParams: Map<String, Any> = emptyMap()
+
+        override val rawName: String
+            get() = superwallEvent.rawName
+
+        override suspend fun getSuperwallParameters(): Map<String, Any> =
+            mapOf(
+                "paywall_id" to paywallId,
+                "preloading_enabled" to preloadingEnabled,
+                "visible_duration" to visibleDuration,
+            ).filter { it.value != null }.toMap() as Map<String, Any>
+
+        override val canImplicitlyTriggerPaywall: Boolean = false
+    }
+
     object ConfirmAllAssignments : InternalSuperwallEvent(SuperwallEvent.ConfirmAllAssignments) {
         override val audienceFilterParams: Map<String, Any> = emptyMap()
 

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -416,6 +416,18 @@ sealed class SuperwallEvent {
         override val rawName: String = SuperwallEvents.CustomPlacement.rawName
     }
 
+    data object ShimmerViewStart : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.ShimmerViewStart.rawName
+    }
+
+    data class ShimmerViewComplete(
+        val duration: Double,
+    ) : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.ShimmerViewComplete.rawName
+    }
+
     internal object ErrorThrown : SuperwallEvent(), IsInternalEvent {
         override val rawName: String
             get() = "error_thrown"

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -48,6 +48,8 @@ enum class SuperwallEvents(
     RestoreFail("restore_fail"),
     RestoreComplete("restore_complete"),
     CustomPlacement("custom_placement"),
+    ShimmerViewStart("shimmerView_start"),
+    ShimmerViewComplete("shimmerView_complete"),
     ConfigAttributes("config_attributes"),
     ConfirmAllAssignments("confirm_all_assignments"),
     ConfigFail("config_fail"),

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -170,6 +170,7 @@ class DependencyContainer(
             track = {
                 Superwall.instance.track(it)
             },
+            shouldTraceResults = makeFeatureFlags()?.enableCELLogging ?: false,
         )
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -643,7 +643,7 @@ class DependencyContainer(
 
     override fun makeTransactionVerifier(): GoogleBillingWrapper = googleBillingWrapper
 
-    override suspend fun makeSuperwallOptions(): SuperwallOptions = configManager.options
+    override fun makeSuperwallOptions(): SuperwallOptions = configManager.options
 
     override suspend fun makeTriggers(): Set<String> = configManager.triggersByEventName.keys
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -184,7 +184,7 @@ interface StoreTransactionFactory {
 }
 
 interface OptionsFactory {
-    suspend fun makeSuperwallOptions(): SuperwallOptions
+    fun makeSuperwallOptions(): SuperwallOptions
 }
 
 interface TriggerFactory {

--- a/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
@@ -41,7 +41,7 @@ data class Config(
                     rawFeatureFlags.find { it.key == "enable_multiple_paywall_urls" }?.enabled
                         ?: false,
                 enableConfigRefresh =
-                    rawFeatureFlags.find { it.key == "enable_config_refresh" }?.enabled
+                    rawFeatureFlags.find { it.key == "enable_config_refresh_v2" }?.enabled
                         ?: false,
                 enableSessionEvents =
                     rawFeatureFlags.find { it.key == "enable_session_events" }?.enabled
@@ -54,6 +54,9 @@ data class Config(
                         ?: false,
                 disableVerboseEvents =
                     rawFeatureFlags.find { it.key == "disable_verbose_events" }?.enabled
+                        ?: false,
+                enableCELLogging =
+                    rawFeatureFlags.find { it.key == "enable_cel_logging" }?.enabled
                         ?: false,
             )
 

--- a/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/FeatureFlags.kt
@@ -13,12 +13,13 @@ data class RawFeatureFlag(
 
 @Serializable
 data class FeatureFlags(
-    @SerialName("enable_config_refresh") var enableConfigRefresh: Boolean = false,
+    @SerialName("enable_config_refresh_v2") var enableConfigRefresh: Boolean = false,
     @SerialName("enable_session_events") var enableSessionEvents: Boolean,
     @SerialName("enable_postback") var enablePostback: Boolean,
     @SerialName("enable_userid_seed") var enableUserIdSeed: Boolean,
     @SerialName("disable_verbose_events") var disableVerboseEvents: Boolean,
     @SerialName("enable_multiple_paywall_urls") var enableMultiplePaywallUrls: Boolean,
+    @SerialName("enable_cel_logging") var enableCELLogging: Boolean,
 )
 
 fun List<RawFeatureFlag>.value(

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -85,6 +85,8 @@ data class Paywall(
     var webviewLoadingInfo: LoadingInfo = LoadingInfo(),
     @kotlinx.serialization.Transient()
     var productsLoadingInfo: LoadingInfo = LoadingInfo(),
+    @kotlinx.serialization.Transient()
+    var shimmerLoadingInfo: LoadingInfo = LoadingInfo(),
     var productVariables: List<ProductVariable>? = null,
     var swProductVariablesTemplate: List<ProductVariable>? = null,
     var paywalljsVersion: String? = null,
@@ -209,6 +211,8 @@ data class Paywall(
             productsLoadStartTime = productsLoadingInfo.startAt,
             productsLoadFailTime = productsLoadingInfo.failAt,
             productsLoadCompleteTime = productsLoadingInfo.endAt,
+            shimmerLoadStartTime = shimmerLoadingInfo.startAt,
+            shimmerLoadCompleteTime = shimmerLoadingInfo.endAt,
             experiment = experiment,
             paywalljsVersion = paywalljsVersion,
             isFreeTrialAvailable = isFreeTrialAvailable,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -52,6 +52,8 @@ data class PaywallInfo(
     val productsLoadStartTime: String?,
     val productsLoadCompleteTime: String?,
     val productsLoadFailTime: String?,
+    val shimmerLoadStartTime: String?,
+    val shimmerLoadCompleteTime: String?,
     val productsLoadDuration: Double?,
     val paywalljsVersion: String?,
     val isFreeTrialAvailable: Boolean,
@@ -83,6 +85,8 @@ data class PaywallInfo(
         productsLoadStartTime: Date?,
         productsLoadFailTime: Date?,
         productsLoadCompleteTime: Date?,
+        shimmerLoadStartTime: Date?,
+        shimmerLoadCompleteTime: Date?,
         experiment: Experiment? = null,
         paywalljsVersion: String? = null,
         isFreeTrialAvailable: Boolean,
@@ -167,6 +171,14 @@ data class PaywallInfo(
                     (endTime.time / 1000 - startTime.time / 1000).toDouble()
                 }
             },
+        shimmerLoadStartTime =
+            webViewLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
+        shimmerLoadCompleteTime =
+            webViewLoadStartTime?.let {
+                DateFormatterUtil.format(it)
+            } ?: "",
         localNotifications = localNotifications,
         computedPropertyRequests = computedPropertyRequests,
         closeReason = closeReason,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/CombinedExpressionEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/CombinedExpressionEvaluator.kt
@@ -23,6 +23,7 @@ internal class CombinedExpressionEvaluator(
     private val storage: LocalStorage,
     private val factory: RuleAttributesFactory,
     private val evaluator: JavascriptEvaluator,
+    private val shouldTraceResults: Boolean,
     private val superscriptEvaluator: SuperscriptEvaluator,
     private val track: suspend (InternalSuperwallEvent.ExpressionResult) -> Unit,
 ) : ExpressionEvaluating {
@@ -48,15 +49,17 @@ internal class CombinedExpressionEvaluator(
             } catch (e: Exception) {
                 TriggerRuleOutcome.noMatch(UnmatchedRule.Source.EXPRESSION, rule.experiment.id)
             }
-        track(
-            InternalSuperwallEvent.ExpressionResult(
-                liquidExpression = rule.expression,
-                celExpression = rule.expressionCEL,
-                celExpressionResult = if (celEvaluation is TriggerRuleOutcome.Match) true else false,
-                jsExpression = rule.expressionJs,
-                jsExpressionResult = if (result is TriggerRuleOutcome.Match) true else false,
-            ),
-        )
+        if (shouldTraceResults) {
+            track(
+                InternalSuperwallEvent.ExpressionResult(
+                    liquidExpression = rule.expression,
+                    celExpression = rule.expressionCEL,
+                    celExpressionResult = if (celEvaluation is TriggerRuleOutcome.Match) true else false,
+                    jsExpression = rule.expressionJs,
+                    jsExpressionResult = if (result is TriggerRuleOutcome.Match) true else false,
+                ),
+            )
+        }
         return result
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -233,7 +233,7 @@ class RawStoreProduct(
         // Check for free trial phase in pricing phases, excluding the base pricing
         selectedOffer.pricingPhases.pricingPhaseList
             .dropLast(1)
-            .any { it.priceAmountMicros == 0L }
+            .isNotEmpty()
     }
 
     override val localizedTrialPeriodPrice by lazy {

--- a/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
@@ -410,7 +410,7 @@ class ProductFetcherInstrumentedTest {
                         offerType = OfferType.Offer(id = "paid-offer"),
                     ),
             )
-        assert(!storeProduct.hasFreeTrial)
+        assert(storeProduct.hasFreeTrial)
         assert(storeProduct.productIdentifier == "com.ui_tests.quarterly2")
         assert(storeProduct.fullIdentifier == "com.ui_tests.quarterly2:test-4:paid-offer")
         assert(storeProduct.currencyCode == "USD")
@@ -513,7 +513,7 @@ class ProductFetcherInstrumentedTest {
                         offerType = OfferType.Auto,
                     ),
             )
-        assert(!storeProduct.hasFreeTrial)
+        assert(storeProduct.hasFreeTrial)
         assert(storeProduct.productIdentifier == "com.ui_tests.quarterly2")
         assert(storeProduct.fullIdentifier == "com.ui_tests.quarterly2:test-3:sw-auto")
         assert(storeProduct.currencyCode == "USD")


### PR DESCRIPTION
## 1.5.0-beta.2

## Enhancements
- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
- Makes `hasFreeTrial` match iOS SDK behavior by returning `true` for both free trials and non-free introductory offers

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)