### PR TITLE
1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 1.5.0
+
+### Enhancements
+
+- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
+- Makes `hasFreeTrial` match iOS SDK behavior by returning `true` for both free trials and non-free introductory offers
+- Adds `Superwall.instance.events` - A SharedFlow instance emitting all Superwall events as `SuperwallEventInfo`. This can be used as an alternative to a delegate for listening to events.
+- Adds a new shimmer animation
+- Adds support for SuperScript expression evaluator
+
+### Fixes
+
+- Fixes concurrency issues with subscriptions triggered in Cordova apps 
+
 ## 1.5.0-beta.2
 
 ## Enhancements

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "1.5.0-beta.2"
+version = "1.5.0"
 
 android {
     compileSdk = 34

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -97,6 +97,7 @@ class ExternalNativePurchaseController(
 
     fun syncSubscriptionStatus() {
         CoroutineScope(Dispatchers.IO).launch {
+            Superwall.hasInitialized.first { it }
             syncSubscriptionStatusAndWait()
         }
     }


### PR DESCRIPTION
## 1.5.0

### Enhancements

- Adds `shimmerView_start` and `shimmerView_complete` events to track the loading of the shimmer animation.
- Makes `hasFreeTrial` match iOS SDK behavior by returning `true` for both free trials and non-free introductory offers
- Adds `Superwall.instance.events` - A SharedFlow instance emitting all Superwall events as `SuperwallEventInfo`. This can be used as an alternative to a delegate for listening to events.
- Adds a new shimmer animation
- Adds support for SuperScript expression evaluator

### Fixes

- Fixes concurrency issues with subscriptions triggered in Cordova apps 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)