### PR TITLE
Transaction Failure fix, Composable cleanup and minor event migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+# 2.0.1
+
+## Enhancements
+- Changes back to `handleSuperwallEvent` naming with a deprecation notice and a typealias for previous methods
+
+## Fixes
+- Removes extra failure logging when displaying alerts
+- Finds nearest activity instead of relying just on Context in `PaywallComposable`
+- Improves cleanup in `PaywallComposable`
+
 # 2.0.0
 
 Our 2.0.0 release brings some major and minor changes to both our API's and core features. For more information, please look at our [migration docs](https://superwall.com/docs/migrating-to-v2-android)

--- a/app/src/main/java/com/superwall/superapp/MainApplication.kt
+++ b/app/src/main/java/com/superwall/superapp/MainApplication.kt
@@ -7,7 +7,7 @@ import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import androidx.appcompat.app.AlertDialog
 import com.superwall.sdk.Superwall
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.config.options.PaywallOptions
 import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.delegate.SuperwallDelegate
@@ -66,7 +66,7 @@ class MainApplication :
 //        configureWithRevenueCatInitialization()
     }
 
-    val events = MutableSharedFlow<SuperwallPlacementInfo>()
+    val events = MutableSharedFlow<SuperwallEventInfo>()
 
     fun configureWithAutomaticInitialization() {
         Superwall.configure(
@@ -150,11 +150,11 @@ class MainApplication :
         super.handleLog(level, scope, message, info, error)
     }
 
-    override fun handleSuperwallPlacement(withInfo: SuperwallPlacementInfo) {
+    override fun handleSuperwallEvent(eventInfo: SuperwallEventInfo) {
         println(
             "\n!! SuperwallDelegate !! \n" +
-                "\tEvent name:" + withInfo.placement.rawName + "" +
-                ",\n\tParams:" + withInfo.params + "\n",
+                "\tEvent name:" + eventInfo.placement.rawName + "" +
+                ",\n\tParams:" + eventInfo.params + "\n",
         )
     }
 }

--- a/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.analytics.superwall.SuperwallPlacement
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.superapp.test.UITestHandler.tests
 import com.superwall.superapp.ui.theme.MyApplicationTheme
@@ -59,7 +59,7 @@ class UITestInfo(
         delay(100)
         Superwall.instance.delegate =
             object : SuperwallDelegate {
-                override fun handleSuperwallPlacement(eventInfo: SuperwallPlacementInfo) {
+                override fun handleSuperwallPlacement(eventInfo: SuperwallEventInfo) {
                     Log.e(
                         "\n!!SuperwallDelegate!!\n",
                         "\tEvent name:" + eventInfo.placement.rawName + "" +

--- a/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestMocks.kt
@@ -1,6 +1,6 @@
 package com.superwall.superapp.test
 
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.view.PaywallView
@@ -26,13 +26,13 @@ class MockPaywallViewDelegate : PaywallViewCallback {
 }
 
 class MockSuperwallDelegate : SuperwallDelegate {
-    private var handleSuperwallEvent: ((SuperwallPlacementInfo) -> Unit)? = null
+    private var handleSuperwallEvent: ((SuperwallEventInfo) -> Unit)? = null
 
-    fun handleSuperwallPlacement(handler: (SuperwallPlacementInfo) -> Unit) {
+    fun handleSuperwallPlacement(handler: (SuperwallEventInfo) -> Unit) {
         handleSuperwallEvent = handler
     }
 
-    override fun handleSuperwallPlacement(withInfo: SuperwallPlacementInfo) {
+    override fun handleSuperwallPlacement(withInfo: SuperwallEventInfo) {
         handleSuperwallEvent?.invoke(withInfo)
     }
 }

--- a/superwall-compose/build.gradle.kts
+++ b/superwall-compose/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("signing")
 }
 
-version = "2.0.0"
+version = "2.0.1"
 
 android {
     namespace = "com.superwall.sdk.composable"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "2.0.0"
+version = "2.0.1"
 
 android {
     compileSdk = 34

--- a/superwall/src/androidTest/java/com/superwall/sdk/ObserverModeTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/ObserverModeTest.kt
@@ -9,8 +9,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.analytics.superwall.SuperwallPlacement
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
 import com.superwall.sdk.billing.BillingError
 import com.superwall.sdk.config.options.PaywallOptions
 import com.superwall.sdk.config.options.SuperwallOptions
@@ -228,7 +228,7 @@ class MockDelegate(
 ) : SuperwallDelegate {
     val events = MutableSharedFlow<SuperwallPlacement>(extraBufferCapacity = 20)
 
-    override fun handleSuperwallPlacement(eventInfo: SuperwallPlacementInfo) {
+    override fun handleSuperwallPlacement(eventInfo: SuperwallEventInfo) {
         Log.e("test", "handle event is ${eventInfo.placement}")
         scope.launch {
             events.emit(eventInfo.placement)

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -9,7 +9,7 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.billing.toInternalResult
 import com.superwall.sdk.config.models.ConfigState
 import com.superwall.sdk.config.models.ConfigurationStatus
@@ -101,7 +101,7 @@ class Superwall(
 
     internal val presentationItems: PresentationItems = PresentationItems()
 
-    private val _placements: MutableSharedFlow<SuperwallPlacementInfo> =
+    private val _placements: MutableSharedFlow<SuperwallEventInfo> =
         MutableSharedFlow(
             0,
             extraBufferCapacity = 64 * 4,
@@ -110,10 +110,10 @@ class Superwall(
 
     /**
      * A flow emitting all Superwall placements as an alternative to delegate.
-     * @see SuperwallPlacementInfo for more information and possible placements
+     * @see SuperwallEventInfo for more information and possible placements
      * */
 
-    val placements: SharedFlow<SuperwallPlacementInfo> = _placements
+    val placements: SharedFlow<SuperwallEventInfo> = _placements
 
     var localeIdentifier: String?
         get() = dependencyContainer.configManager.options.localeIdentifier
@@ -180,7 +180,7 @@ class Superwall(
         }
     }
 
-    internal fun emitSuperwallEvent(info: SuperwallPlacementInfo) {
+    internal fun emitSuperwallEvent(info: SuperwallEventInfo) {
         ioScope.launch {
             _placements.emit(info)
         }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -3,7 +3,7 @@ package com.superwall.sdk.analytics.internal
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.trackable.Trackable
 import com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
@@ -53,7 +53,7 @@ suspend fun Superwall.track(event: Trackable): Result<TrackingResult> {
         // For a trackable superwall event, send params to delegate
         if (event is TrackableSuperwallEvent) {
             val info =
-                SuperwallPlacementInfo(
+                SuperwallEventInfo(
                     placement = event.superwallPlacement,
                     params = parameters.delegateParams,
                 )

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -261,13 +261,12 @@ sealed class InternalSuperwallEvent(
     ) : InternalSuperwallEvent(SuperwallPlacement.SubscriptionStatusDidChange()) {
         override suspend fun getSuperwallParameters(): HashMap<String, Any> =
             hashMapOf(
-                "subscription_status" to {
+                "subscription_status" to
                     when (subscriptionStatus) {
                         is SubscriptionStatus.Active -> "active"
                         is SubscriptionStatus.Inactive -> "inactive"
                         is SubscriptionStatus.Unknown -> "unknown"
-                    }
-                },
+                    },
             )
     }
 
@@ -846,7 +845,13 @@ sealed class InternalSuperwallEvent(
         val placementName: String,
         val paywallInfo: PaywallInfo,
         val params: Map<String, Any>,
-    ) : InternalSuperwallEvent(SuperwallPlacement.CustomPlacement(placementName, paywallInfo, params)) {
+    ) : InternalSuperwallEvent(
+            SuperwallPlacement.CustomPlacement(
+                placementName,
+                paywallInfo,
+                params,
+            ),
+        ) {
         override val audienceFilterParams: Map<String, Any>
             get() = paywallInfo.audienceFilterParams() + params
 
@@ -894,7 +899,8 @@ sealed class InternalSuperwallEvent(
         override val canImplicitlyTriggerPaywall: Boolean = false
     }
 
-    object ConfirmAllAssignments : InternalSuperwallEvent(SuperwallPlacement.ConfirmAllAssignments) {
+    object ConfirmAllAssignments :
+        InternalSuperwallEvent(SuperwallPlacement.ConfirmAllAssignments) {
         override val audienceFilterParams: Map<String, Any> = emptyMap()
 
         override suspend fun getSuperwallParameters(): Map<String, Any> = emptyMap()

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEventInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEventInfo.kt
@@ -1,6 +1,6 @@
 package com.superwall.sdk.analytics.superwall
 
-data class SuperwallPlacementInfo(
+data class SuperwallEventInfo(
     public val placement: SuperwallPlacement,
     public val params: Map<String, Any>,
 )

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEventInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEventInfo.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.analytics.superwall
 
+@Deprecated("Use SuperwallEventInfo instead")
+typealias SuperwallPlacementInfo = SuperwallEventInfo
+
 data class SuperwallEventInfo(
     public val placement: SuperwallPlacement,
     public val params: Map<String, Any>,

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
@@ -762,7 +762,7 @@ class DebugView(
         // Set the completion callback
         SWLocalizationActivity.completion = { locale ->
             // Handle the locale identifier
-            Superwall.instance.options.localeIdentifier = locale
+            Superwall.instance.localeIdentifier = locale
             // Continue with any other operations after locale selection
             CoroutineScope(Dispatchers.IO).launch {
                 loadPreview()

--- a/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegate.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.delegate
 
 import android.net.Uri
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import java.net.URI
@@ -12,7 +12,10 @@ interface SuperwallDelegate {
         to: SubscriptionStatus,
     ) {}
 
-    fun handleSuperwallPlacement(eventInfo: SuperwallPlacementInfo) {}
+    fun handleSuperwallEvent(eventInfo: SuperwallEventInfo) {}
+
+    @Deprecated("Use handleSuperwallEvent instead")
+    fun handleSuperwallPlacement(eventInfo: SuperwallEventInfo) {}
 
     fun handleCustomPaywallAction(withName: String) {}
 

--- a/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
@@ -46,7 +46,9 @@ class SuperwallDelegateAdapter {
     }
 
     fun handleSuperwallEvent(eventInfo: SuperwallEventInfo) {
+        // Calling this until we deprecate it
         kotlinDelegate?.handleSuperwallPlacement(eventInfo)
+        kotlinDelegate?.handleSuperwallEvent(eventInfo)
             ?: javaDelegate?.handleSuperwallEvent(eventInfo)
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.delegate
 
 import android.net.Uri
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import java.net.URI
@@ -45,7 +45,7 @@ class SuperwallDelegateAdapter {
             ?: javaDelegate?.paywallWillOpenDeepLink(url)
     }
 
-    fun handleSuperwallEvent(eventInfo: SuperwallPlacementInfo) {
+    fun handleSuperwallEvent(eventInfo: SuperwallEventInfo) {
         kotlinDelegate?.handleSuperwallPlacement(eventInfo)
             ?: javaDelegate?.handleSuperwallEvent(eventInfo)
     }

--- a/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateJava.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateJava.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.delegate
 
 import android.net.Uri
-import com.superwall.sdk.analytics.superwall.SuperwallPlacementInfo
+import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import java.net.URI
@@ -21,7 +21,7 @@ interface SuperwallDelegateJava {
 
     fun paywallWillOpenDeepLink(url: Uri) {}
 
-    fun handleSuperwallEvent(eventInfo: SuperwallPlacementInfo) {}
+    fun handleSuperwallEvent(eventInfo: SuperwallEventInfo) {}
 
     fun subscriptionStatusDidChange(
         from: SubscriptionStatus,

--- a/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
@@ -5,16 +5,19 @@ import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.Either
 import com.superwall.sdk.misc.flatMap
+import com.superwall.sdk.misc.map
 import com.superwall.sdk.misc.retrying
 import com.superwall.sdk.network.NetworkError
 import com.superwall.sdk.network.NetworkRequestData
 import com.superwall.sdk.network.RequestExecutor
+import com.superwall.sdk.network.RequestResult
 import com.superwall.sdk.network.authHeader
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 class CustomHttpUrlConnection(
     val json: Json,
+    val interceptors: List<(RequestResult) -> RequestResult> = emptyList(),
     val requestExecutor: RequestExecutor,
 ) {
     @Throws(NetworkError::class)
@@ -28,29 +31,37 @@ class CustomHttpUrlConnection(
             isRetryingCallback = isRetryingCallback,
         ) {
             val requestData = buildRequestData()
-            requestExecutor.execute(requestData).flatMap {
-                try {
-                    Either.Success(
-                        this.json.decodeFromString<Response>(
-                            it.responseMessage,
-                        ),
-                    )
-                } catch (e: Throwable) {
-                    Logger.debug(
-                        LogLevel.error,
-                        LogScope.network,
-                        "Request Error",
-                        mapOf(
-                            "request" to it.toString(),
-                            "api_key" to it.authHeader(),
-                            "url" to (requestData.url?.toString() ?: "unknown"),
-                            "message" to "Unable to decode response to type ${Response::class.simpleName}",
-                            "info" to it.responseMessage,
-                            "request_duration" to it.duration,
-                        ),
-                    )
-                    Either.Failure(NetworkError.Decoding(e))
+            requestExecutor
+                .execute(requestData)
+                .map {
+                    if (interceptors.isNotEmpty()) {
+                        interceptors.fold(it, { res, interceptor -> interceptor(res) })
+                    } else {
+                        it
+                    }
+                }.flatMap {
+                    try {
+                        Either.Success(
+                            this.json.decodeFromString<Response>(
+                                it.responseMessage,
+                            ),
+                        )
+                    } catch (e: Throwable) {
+                        Logger.debug(
+                            LogLevel.error,
+                            LogScope.network,
+                            "Request Error",
+                            mapOf(
+                                "request" to it.toString(),
+                                "api_key" to it.authHeader(),
+                                "url" to (requestData.url?.toString() ?: "unknown"),
+                                "message" to "Unable to decode response to type ${Response::class.simpleName}",
+                                "info" to it.responseMessage,
+                                "request_duration" to it.duration,
+                            ),
+                        )
+                        Either.Failure(NetworkError.Decoding(e))
+                    }
                 }
-            }
         }
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -789,24 +789,6 @@ class TransactionManager(
             )
         }
 
-        val paywallInfo = paywallView.info
-
-        val trackedEvent =
-            InternalSuperwallEvent.Transaction(
-                InternalSuperwallEvent.Transaction.State.Fail(
-                    TransactionError.Failure(
-                        error.message ?: "",
-                        product,
-                    ),
-                ),
-                paywallInfo,
-                product,
-                null,
-                source = TransactionSource.INTERNAL,
-                isObserved = factory.makeSuperwallOptions().shouldObservePurchases,
-            )
-        track(trackedEvent)
-
         paywallView.showAlert(
             "An error occurred",
             error.message ?: "Unknown error",

--- a/superwall/src/test/java/com/superwall/sdk/store/transactions/TransactionManagerTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/store/transactions/TransactionManagerTest.kt
@@ -416,6 +416,7 @@ class TransactionManagerTest {
                                 isNull(),
                             )
                         }
+                        advanceUntilIdle()
                         And("Verify failure event") {
                             val failureEvent =
                                 events.value


### PR DESCRIPTION
## Changes in this pull request

## Enhancements
- Changes back to `handleSuperwallEvent` naming with a deprecation notice and a typealias for previous methods

## Fixes
- Removes extra failure logging when displaying alerts
- Finds nearest activity instead of relying just on Context in `PaywallComposable`
- Improves cleanup in `PaywallComposable`

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)