### PR TITLE
Fix missing tx identifier when using external purchase controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 2.0.5
+
+## Fixes
+- Fix issue with `original_transaction_id` missing when using a `PurchaseController`
+
 # 2.0.4
 
 ## Enhancements

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,9 +70,11 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout_version" }
 core_ktx = { module = "androidx.core:core-ktx", version.ref = "core_ktx_version" }
 lifecycle_runtime_ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle_runtime_ktx_version" }
+lifecycle_testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "lifecycle_runtime_ktx_version" }
 uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator_version" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx_version" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleProcessVersion" }
+
 
 # Coroutines
 kotlinx_coroutines_core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx_coroutines_core_version" }

--- a/superwall-compose/build.gradle.kts
+++ b/superwall-compose/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("signing")
 }
 
-version = "2.0.3"
+version = "2.0.5"
 
 android {
     namespace = "com.superwall.sdk.composable"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "2.0.4"
+version = "2.0.5"
 
 android {
     compileSdk = 34
@@ -221,4 +221,5 @@ dependencies {
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.mockk.android)
+    androidTestImplementation(libs.lifecycle.testing)
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/network/BaseHostServiceTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/network/BaseHostServiceTest.kt
@@ -41,6 +41,7 @@ class BaseHostServiceTest {
                     CustomHttpUrlConnection(
                         Json { ignoreUnknownKeys = true },
                         executor,
+                        emptyList(),
                     ),
             )
     }

--- a/superwall/src/androidTest/java/com/superwall/sdk/network/CollectorServiceTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/network/CollectorServiceTest.kt
@@ -41,6 +41,7 @@ class CollectorServiceTest {
                     CustomHttpUrlConnection(
                         Json { ignoreUnknownKeys = true },
                         executor,
+                        emptyList(),
                     ),
             )
     }

--- a/superwall/src/androidTest/java/com/superwall/sdk/network/GeoServiceTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/network/GeoServiceTest.kt
@@ -37,6 +37,7 @@ class GeoServiceTest {
                     CustomHttpUrlConnection(
                         Json { ignoreUnknownKeys = true },
                         executor,
+                        emptyList(),
                     ),
             )
     }

--- a/superwall/src/androidTest/java/com/superwall/sdk/utilities/PurchaseMockBuilder.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/utilities/PurchaseMockBuilder.kt
@@ -1,6 +1,13 @@
 package com.superwall.sdk.utilities
 
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.ProductDetails.OneTimePurchaseOfferDetails
+import com.android.billingclient.api.ProductDetails.PricingPhase
+import com.android.billingclient.api.ProductDetails.RecurrenceMode
 import com.android.billingclient.api.Purchase
+import io.mockk.every
+import io.mockk.mockk
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -89,3 +96,70 @@ class PurchaseMockBuilder {
                 .build()
     }
 }
+
+fun mockProductDetails(
+    productId: String = "sample_product_id",
+    @BillingClient.ProductType type: String = BillingClient.ProductType.SUBS,
+    oneTimePurchaseOfferDetails: ProductDetails.OneTimePurchaseOfferDetails? = null,
+    subscriptionOfferDetails: List<ProductDetails.SubscriptionOfferDetails>? =
+        listOf(
+            mockSubscriptionOfferDetails(),
+        ),
+    name: String = "subscription_mock_name",
+    description: String = "subscription_mock_description",
+    title: String = "subscription_mock_title",
+): ProductDetails =
+    mockk<ProductDetails>().apply {
+        every { getProductId() } returns productId
+        every { productType } returns type
+        every { getName() } returns name
+        every { getDescription() } returns description
+        every { getTitle() } returns title
+        every { getOneTimePurchaseOfferDetails() } returns oneTimePurchaseOfferDetails
+        every { getSubscriptionOfferDetails() } returns subscriptionOfferDetails
+        every { zza() } returns "mock-package-name" // This seems to return the packageName property from the response json
+    }
+
+fun mockOneTimePurchaseOfferDetails(
+    price: Double = 4.99,
+    priceCurrencyCodeValue: String = "USD",
+): OneTimePurchaseOfferDetails =
+    mockk<OneTimePurchaseOfferDetails>().apply {
+        every { formattedPrice } returns "${'$'}$price"
+        every { priceAmountMicros } returns price.times(1_000_000).toLong()
+        every { priceCurrencyCode } returns priceCurrencyCodeValue
+    }
+
+fun mockSubscriptionOfferDetails(
+    tags: List<String> = emptyList(),
+    token: String = "mock-subscription-offer-token",
+    offerId: String = "mock-offer-id",
+    basePlanId: String = "mock-base-plan-id",
+    pricingPhases: List<PricingPhase> = listOf(mockPricingPhase()),
+): ProductDetails.SubscriptionOfferDetails =
+    mockk<ProductDetails.SubscriptionOfferDetails>().apply {
+        every { offerTags } returns tags
+        every { offerToken } returns token
+        every { getOfferId() } returns offerId
+        every { getBasePlanId() } returns basePlanId
+        every { getPricingPhases() } returns
+            mockk<ProductDetails.PricingPhases>().apply {
+                every { pricingPhaseList } returns pricingPhases
+            }
+    }
+
+fun mockPricingPhase(
+    price: Double = 4.99,
+    priceCurrencyCodeValue: String = "USD",
+    billingPeriod: String = "P1M",
+    billingCycleCount: Int = 0,
+    recurrenceMode: Int = RecurrenceMode.INFINITE_RECURRING,
+): PricingPhase =
+    mockk<PricingPhase>().apply {
+        every { formattedPrice } returns "${'$'}$price"
+        every { priceAmountMicros } returns price.times(1_000_000).toLong()
+        every { priceCurrencyCode } returns priceCurrencyCodeValue
+        every { getBillingPeriod() } returns billingPeriod
+        every { getBillingCycleCount() } returns billingCycleCount
+        every { getRecurrenceMode() } returns recurrenceMode
+    }

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -59,8 +59,7 @@ class GoogleBillingWrapper(
 
     private val threadHandler = Handler(ioScope)
     private val shouldFinishTransactions: Boolean
-        get() =
-            factory.makeHasInternalPurchaseController()
+        get() = !factory.makeSuperwallOptions().shouldObservePurchases
 
     @get:Synchronized
     @set:Synchronized


### PR DESCRIPTION
## Changes in this pull request

- Fix missing transaction identifier when using external purchase controller

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)