### PR TITLE
Add externalAccountId to redeemrequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 2.2.4
+
+## Enhancements
+
+- Adds `externalAcountId`, provided to Google Play billing upon purchase as a SHA256 of the userId or the userId itself if `passIdentifiersToPlayStore` option is provided.
+
 ## 2.2.3
 
 ## Fixes

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -301,6 +301,14 @@ class Superwall(
         get() = dependencyContainer.identityManager.userId
 
     /**
+     * The externalAccountId for the current user.
+     * Provided to Google Play billing upon purchase as a SHA256 of the userId.
+     * If `passIdentifiersToPlayStore` option is provided, this will be the userId.
+     */
+    val externalAccountId: String
+        get() = dependencyContainer.identityManager.externalAccountId
+
+    /**
      * Indicates whether the user is logged in to Superwall.
      *
      * If you have previously called `identify(userId:options:)`, this will

--- a/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
@@ -36,6 +36,7 @@ class IdentityManager(
     private val storage: LocalStorage,
     private val configManager: ConfigManager,
     private val ioScope: IOScope,
+    private val stringToSha: (String) -> String = { it },
 ) {
     private var _appUserId: String? = storage.read(AppUserId)
 
@@ -47,6 +48,16 @@ class IdentityManager(
 
     private var _aliasId: String =
         storage.read(AliasId) ?: IdentityLogic.generateAlias()
+
+    val externalAccountId: String
+        get() =
+            runBlocking(queue) {
+                if (configManager.options.passIdentifiersToPlayStore) {
+                    stringToSha(userId)
+                } else {
+                    userId
+                }
+            }
 
     val aliasId: String
         get() =

--- a/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
@@ -53,9 +53,9 @@ class IdentityManager(
         get() =
             runBlocking(queue) {
                 if (configManager.options.passIdentifiersToPlayStore) {
-                    stringToSha(userId)
-                } else {
                     userId
+                } else {
+                    stringToSha(userId)
                 }
             }
 

--- a/superwall/src/main/java/com/superwall/sdk/models/entitlements/RedeemRequest.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/entitlements/RedeemRequest.kt
@@ -15,6 +15,8 @@ data class RedeemRequest(
     val codes: List<Redeemable>,
     @SerialName("receipts")
     val receipts: List<TransactionReceipt>,
+    @SerialName("externalAccountId")
+    val externalAccountId: String,
 )
 
 @Serializable

--- a/superwall/src/main/java/com/superwall/sdk/network/Network.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Network.kt
@@ -131,9 +131,10 @@ open class Network(
         aliasId: String?,
         vendorId: DeviceVendorId,
         receipts: List<TransactionReceipt>,
+        externalAccountId: String,
     ): Either<WebRedemptionResponse, NetworkError> =
         subscriptionService
-            .redeemToken(codes, userId, aliasId, vendorId, receipts)
+            .redeemToken(codes, userId, aliasId, vendorId, receipts, externalAccountId)
             .logError("/redeem")
 
     override suspend fun webEntitlementsByUserId(

--- a/superwall/src/main/java/com/superwall/sdk/network/SubscriptionService.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/SubscriptionService.kt
@@ -36,6 +36,7 @@ class SubscriptionService(
         aliasId: String?,
         vendorId: DeviceVendorId,
         transactionReceipt: List<TransactionReceipt>,
+        externalAccountId: String,
     ) = post<WebRedemptionResponse>(
         "redeem",
         retryCount = 0,
@@ -48,6 +49,7 @@ class SubscriptionService(
                         aliasId,
                         codes,
                         transactionReceipt,
+                        externalAccountId,
                     ),
                 ).toByteArray(),
     )

--- a/superwall/src/main/java/com/superwall/sdk/network/SuperwallAPI.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/SuperwallAPI.kt
@@ -52,5 +52,6 @@ interface SuperwallAPI {
         aliasId: String?,
         vendorId: DeviceVendorId,
         receipts: List<TransactionReceipt>,
+        externalAccountId: String,
     ): Either<WebRedemptionResponse, NetworkError>
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -199,11 +199,7 @@ class AutomaticPurchaseController(
             BillingFlowParams
                 .newBuilder()
                 .apply {
-                    if (shouldPassIdToPlayStore && id != null) {
-                        setObfuscatedAccountId(id)
-                    } else {
-                        setObfuscatedAccountId(Superwall.instance.externalAccountId)
-                    }
+                    setObfuscatedAccountId(Superwall.instance.externalAccountId)
                 }.setProductDetailsParamsList(listOf(productDetailsParams))
                 .build()
 

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -201,6 +201,8 @@ class AutomaticPurchaseController(
                 .apply {
                     if (shouldPassIdToPlayStore && id != null) {
                         setObfuscatedAccountId(id)
+                    } else {
+                        setObfuscatedAccountId(Superwall.instance.externalAccountId)
                     }
                 }.setProductDetailsParamsList(listOf(productDetailsParams))
                 .build()

--- a/superwall/src/main/java/com/superwall/sdk/web/WebPaywallRedeemer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/web/WebPaywallRedeemer.kt
@@ -68,6 +68,7 @@ class WebPaywallRedeemer(
     val trackRestorationFailed: (message: String) -> Unit,
     val isWebToAppEnabled: () -> Boolean,
     val receipts: suspend () -> List<TransactionReceipt>,
+    val getExternalAccountId: () -> String,
 ) {
     private var pollingJob: Job? = null
 
@@ -140,6 +141,7 @@ class WebPaywallRedeemer(
                     getAliasId(),
                     getDeviceId(),
                     receipts(),
+                    getExternalAccountId(),
                 ).fold(
                     onSuccess = {
                         storage.write(LatestRedemptionResponse, it)


### PR DESCRIPTION
## Changes in this pull request

- Add `externalAccountId` to subscription redemption
- Add dispatching userId SHA as an `externalAccountId` to Play billing  

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `ktlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)