### PR TITLE
Ir/feat/experimental device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## Enhancements
 
 - Adds `externalAcountId`, provided to Google Play billing upon purchase as a SHA256 of the userId or the userId itself if `passIdentifiersToPlayStore` option is provided.
+-  Adds a `SuperwallOption` named `enableExperimentalDeviceVariables`. When set to true, this enables additional device-level variables: `latestSubscriptionPeriodType`, `latestSubscriptionState`, and `latestSubscriptionWillAutoRenew`. These properties provide information about the most recent Google Play subscription on the device and can be used in audience filters. Note that due to their experimental nature, they are subject to change in future updates.
 
 ## Fixes
 - Fixes issues with paywall destruction when activity performs a hot reload (i.e. during update)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-billing_version = "6.1.0"
+billing_version = "7.1.1"
 browser_version = "1.5.0"
 gradle_plugin_version = "8.6.0"
 jna_version = "5.14.0@aar"

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -419,10 +419,10 @@ class GoogleBillingWrapper(
 
                 BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
                 BillingClient.BillingResponseCode.BILLING_UNAVAILABLE,
-                    -> {
+                -> {
                     val originalErrorMessage =
                         "DebugMessage: ${billingResult.debugMessage} " +
-                                "ErrorCode: ${billingResult.responseCode}."
+                            "ErrorCode: ${billingResult.responseCode}."
 
                     /**
                      * We check for cases when Google sends Google Play In-app Billing API version is less than 3
@@ -439,14 +439,14 @@ class GoogleBillingWrapper(
                         if (billingResult.debugMessage == IN_APP_BILLING_LESS_THAN_3_ERROR_MESSAGE) {
                             val message =
                                 "Billing is not available in this device. Make sure there's an " +
-                                        "account configured in Play Store. Reopen the Play Store or clean its caches if this " +
-                                        "keeps happening. " +
-                                        "Original error message: $originalErrorMessage"
+                                    "account configured in Play Store. Reopen the Play Store or clean its caches if this " +
+                                    "keeps happening. " +
+                                    "Original error message: $originalErrorMessage"
                             BillingError.BillingNotAvailable(message)
                         } else {
                             val message =
                                 "Billing is not available in this device. " +
-                                        "Original error message: $originalErrorMessage"
+                                    "Original error message: $originalErrorMessage"
                             BillingError.BillingNotAvailable(message)
                         }
 
@@ -466,7 +466,7 @@ class GoogleBillingWrapper(
                 BillingClient.BillingResponseCode.USER_CANCELED,
                 BillingClient.BillingResponseCode.SERVICE_DISCONNECTED,
                 BillingClient.BillingResponseCode.NETWORK_ERROR,
-                    -> {
+                -> {
                     Logger.debug(
                         LogLevel.error,
                         LogScope.productsManager,
@@ -478,7 +478,7 @@ class GoogleBillingWrapper(
                 BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
                 BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED,
                 BillingClient.BillingResponseCode.ITEM_NOT_OWNED,
-                    -> {
+                -> {
                     Logger.debug(
                         LogLevel.error,
                         LogScope.productsManager,
@@ -611,26 +611,31 @@ class GoogleBillingWrapper(
         }
     }
 
-    internal suspend fun latestPurchase() = queryAllPurchases().sortedByDescending {
-        it.purchaseTime
-    }.map {
-        val product = awaitGetProducts(it.products.toSet()).first()
-        val millisSincePurchase = (System.currentTimeMillis() - it.purchaseTime)
-        val subPeriod = product.subscriptionPeriod?.toMillis() ?: 0
-        val isGracePeriod = it.purchaseState == Purchase.PurchaseState.PENDING &&
-                it.isAutoRenewing
-        val isExpired = it.purchaseState == Purchase.PurchaseState.PURCHASED
-                && !it.isAutoRenewing &&  millisSincePurchase > subPeriod
-        val isSubscribed = it.purchaseState == Purchase.PurchaseState.PURCHASED
-                && millisSincePurchase < subPeriod
+    internal suspend fun latestPurchase() =
+        queryAllPurchases()
+            .sortedByDescending {
+                it.purchaseTime
+            }.map {
+                val product = awaitGetProducts(it.products.toSet()).first()
+                val millisSincePurchase = (System.currentTimeMillis() - it.purchaseTime)
+                val subPeriod = product.subscriptionPeriod?.toMillis() ?: 0
+                val isGracePeriod =
+                    it.purchaseState == Purchase.PurchaseState.PENDING &&
+                        it.isAutoRenewing
+                val isExpired =
+                    it.purchaseState == Purchase.PurchaseState.PURCHASED &&
+                        !it.isAutoRenewing &&
+                        millisSincePurchase > subPeriod
+                val isSubscribed =
+                    it.purchaseState == Purchase.PurchaseState.PURCHASED &&
+                        millisSincePurchase < subPeriod
 
-        mapOf(
-            "latestSubscriptionPeriodType" to product.subscriptionPeriod?.unit,
-            "latestSubscriptionState" to it.purchaseState,
-            "latestSubscriptionWillAutoRenew" to it.isAutoRenewing
-        )
-    }
-
+                mapOf(
+                    "latestSubscriptionPeriodType" to product.subscriptionPeriod?.unit,
+                    "latestSubscriptionState" to it.purchaseState,
+                    "latestSubscriptionWillAutoRenew" to it.isAutoRenewing,
+                )
+            }
 }
 
 fun Pair<BillingResult, List<Purchase>?>.toInternalResult(): List<InternalPurchaseResult> {

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -6,6 +6,7 @@ import com.android.billingclient.api.BillingClient.ProductType
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryPurchasesParams
 import com.superwall.sdk.delegate.InternalPurchaseResult

--- a/superwall/src/main/java/com/superwall/sdk/billing/observer/SuperwallBillingFlowParams.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/observer/SuperwallBillingFlowParams.kt
@@ -107,27 +107,9 @@ class SuperwallBillingFlowParams private constructor(
                     builder.setOldPurchaseToken(purchaseToken)
                 }
 
-            @Deprecated("Use setOldPurchaseToken instead")
-            fun setOldSkuPurchaseToken(purchaseToken: String): SubscriptionUpdateParamsBuilder =
-                apply {
-                    builder.setOldSkuPurchaseToken(purchaseToken)
-                }
-
             fun setOriginalExternalTransactionId(externalTransactionId: String): SubscriptionUpdateParamsBuilder =
                 apply {
                     builder.setOriginalExternalTransactionId(externalTransactionId)
-                }
-
-            @Deprecated("Use setSubscriptionReplacementMode instead")
-            fun setReplaceProrationMode(replaceSkusProrationMode: Int): SubscriptionUpdateParamsBuilder =
-                apply {
-                    builder.setReplaceProrationMode(replaceSkusProrationMode)
-                }
-
-            @Deprecated("Use setSubscriptionReplacementMode instead")
-            fun setReplaceSkusProrationMode(replaceSkusProrationMode: Int): SubscriptionUpdateParamsBuilder =
-                apply {
-                    builder.setReplaceSkusProrationMode(replaceSkusProrationMode)
                 }
 
             fun setSubscriptionReplacementMode(subscriptionReplacementMode: Int): SubscriptionUpdateParamsBuilder =

--- a/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
@@ -94,6 +94,9 @@ class SuperwallOptions {
     // Enables passing identifier to the Play Store as AccountId's. Defaults to `false`.
     var passIdentifiersToPlayStore: Boolean = false
 
+    // Enables experimental device variables. These are subject to change. Defaults to `false`.
+    var enableExperimentalDeviceVariables: Boolean = false
+
     // Configuration for printing to the console.
     class Logging {
         // Defines the minimum log level to print to the console. Defaults to `warn`.

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -458,6 +458,9 @@ class DependencyContainer(
                 entitlementsById = {
                     entitlements.byProductId(it)
                 },
+                refreshReceipt = {
+                    storeManager.refreshReceipt()
+                },
             )
 
         /**
@@ -844,4 +847,6 @@ class DependencyContainer(
     }
 
     override fun context(): Context = context
+
+    override fun experimentalProperties(): Map<String, Any> = storeManager.receiptManager.experimentalProperties()
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -187,6 +187,10 @@ interface StoreTransactionFactory {
     suspend fun activeProductIds(): List<String>
 }
 
+interface ExperimentalPropertiesFactory {
+    fun experimentalProperties(): Map<String, Any>
+}
+
 interface OptionsFactory {
     fun makeSuperwallOptions(): SuperwallOptions
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -166,8 +166,8 @@ class AutomaticPurchaseController(
                 .also {
                     // Do not set empty offer token for one time products
                     // as Google play is not supporting it since June 12th 2024
-                    if (!isOneTime) {
-                        it.setOfferToken(offerToken ?: "")
+                    if (!isOneTime && offerToken!=null) {
+                        it.setOfferToken(offerToken)
                     }
                 }.build()
 

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -166,7 +166,7 @@ class AutomaticPurchaseController(
                 .also {
                     // Do not set empty offer token for one time products
                     // as Google play is not supporting it since June 12th 2024
-                    if (!isOneTime && offerToken!=null) {
+                    if (!isOneTime && offerToken != null) {
                         it.setOfferToken(offerToken)
                     }
                 }.build()

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreKit.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreKit.kt
@@ -22,7 +22,7 @@ interface StoreKit {
         substituteProducts: Map<String, StoreProduct>? = null,
     ): Map<String, StoreProduct>
 
-    suspend fun refreshReceipt()
+    fun refreshReceipt()
 
     suspend fun loadPurchasedProducts()
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreManager.kt
@@ -218,7 +218,7 @@ class StoreManager(
         )
     }
 
-    override suspend fun refreshReceipt() {
+    override fun refreshReceipt() {
         Logger.debug(
             logLevel = LogLevel.debug,
             scope = LogScope.storeKitManager, // Rename this scope to reflect Billing Manager

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -85,6 +85,7 @@ data class SubscriptionPeriod(
                         period.toTotalMonths().toInt(),
                         Unit.month,
                     )
+
                 period.years > 0 -> SubscriptionPeriod(period.years, Unit.year)
                 else -> null
             }?.normalized()
@@ -94,6 +95,12 @@ data class SubscriptionPeriod(
     private val roundingMode = RoundingMode.DOWN
     private val calculationScale = 7
     private val outputScale = 2
+
+    val toMillis: Long
+        get() {
+            val days = (this.value * this.daysPerUnit).toLong()
+            return days * 24 * 60 * 60 * 1000 // days → hours → minutes → seconds → milliseconds
+        }
 
     fun pricePerDay(price: BigDecimal): BigDecimal {
         val periodsPerDay: BigDecimal =

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -24,6 +24,16 @@ data class SubscriptionPeriod(
                 Unit.year -> 365.0
             }
 
+    fun toMillis(): Long {
+        val days = when (unit) {
+            SubscriptionPeriod.Unit.day -> value
+            Unit.week -> value * 7
+            SubscriptionPeriod.Unit.month -> value * 30  // Approximation
+            SubscriptionPeriod.Unit.year -> value * 365 // Approximation
+        }
+        return days * 24L * 60 * 60 * 1000
+    }
+
     fun normalized(): SubscriptionPeriod =
         when (unit) {
             Unit.day ->

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -25,12 +25,13 @@ data class SubscriptionPeriod(
             }
 
     fun toMillis(): Long {
-        val days = when (unit) {
-            SubscriptionPeriod.Unit.day -> value
-            Unit.week -> value * 7
-            SubscriptionPeriod.Unit.month -> value * 30  // Approximation
-            SubscriptionPeriod.Unit.year -> value * 365 // Approximation
-        }
+        val days =
+            when (unit) {
+                Unit.day -> value
+                Unit.week -> value * 7
+                Unit.month -> value * 30 // Approximation
+                Unit.year -> value * 365 // Approximation
+            }
         return days * 24L * 60 * 60 * 1000
     }
 
@@ -97,10 +98,10 @@ data class SubscriptionPeriod(
     fun pricePerDay(price: BigDecimal): BigDecimal {
         val periodsPerDay: BigDecimal =
             when (this.unit) {
-                SubscriptionPeriod.Unit.day -> BigDecimal.ONE
-                SubscriptionPeriod.Unit.week -> BigDecimal(7)
-                SubscriptionPeriod.Unit.month -> BigDecimal(30)
-                SubscriptionPeriod.Unit.year -> BigDecimal(365)
+                Unit.day -> BigDecimal.ONE
+                Unit.week -> BigDecimal(7)
+                Unit.month -> BigDecimal(30)
+                Unit.year -> BigDecimal(365)
             } * BigDecimal(this.value)
 
         return price.divide(periodsPerDay, outputScale, roundingMode)
@@ -109,10 +110,10 @@ data class SubscriptionPeriod(
     fun pricePerWeek(price: BigDecimal): BigDecimal {
         val periodsPerWeek: BigDecimal =
             when (this.unit) {
-                SubscriptionPeriod.Unit.day -> BigDecimal.ONE.divide(BigDecimal(7), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.week -> BigDecimal.ONE
-                SubscriptionPeriod.Unit.month -> BigDecimal(4)
-                SubscriptionPeriod.Unit.year -> BigDecimal(52)
+                Unit.day -> BigDecimal.ONE.divide(BigDecimal(7), calculationScale, roundingMode)
+                Unit.week -> BigDecimal.ONE
+                Unit.month -> BigDecimal(4)
+                Unit.year -> BigDecimal(52)
             } * BigDecimal(this.value)
 
         return price.divide(periodsPerWeek, outputScale, roundingMode)
@@ -121,10 +122,10 @@ data class SubscriptionPeriod(
     fun pricePerMonth(price: BigDecimal): BigDecimal {
         val periodsPerMonth: BigDecimal =
             when (this.unit) {
-                SubscriptionPeriod.Unit.day -> BigDecimal.ONE.divide(BigDecimal(30), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.week -> BigDecimal.ONE.divide(BigDecimal(30.0 / 7.0), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.month -> BigDecimal.ONE
-                SubscriptionPeriod.Unit.year -> BigDecimal(12)
+                Unit.day -> BigDecimal.ONE.divide(BigDecimal(30), calculationScale, roundingMode)
+                Unit.week -> BigDecimal.ONE.divide(BigDecimal(30.0 / 7.0), calculationScale, roundingMode)
+                Unit.month -> BigDecimal.ONE
+                Unit.year -> BigDecimal(12)
             } * BigDecimal(this.value)
 
         return price.divide(periodsPerMonth, outputScale, roundingMode)
@@ -133,10 +134,10 @@ data class SubscriptionPeriod(
     fun pricePerYear(price: BigDecimal): BigDecimal {
         val periodsPerYear: BigDecimal =
             when (this.unit) {
-                SubscriptionPeriod.Unit.day -> BigDecimal.ONE.divide(BigDecimal(365), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.week -> BigDecimal.ONE.divide(BigDecimal(52), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.month -> BigDecimal.ONE.divide(BigDecimal(12), calculationScale, roundingMode)
-                SubscriptionPeriod.Unit.year -> BigDecimal.ONE
+                Unit.day -> BigDecimal.ONE.divide(BigDecimal(365), calculationScale, roundingMode)
+                Unit.week -> BigDecimal.ONE.divide(BigDecimal(52), calculationScale, roundingMode)
+                Unit.month -> BigDecimal.ONE.divide(BigDecimal(12), calculationScale, roundingMode)
+                Unit.year -> BigDecimal.ONE
             }.multiply(BigDecimal(this.value))
 
         return price.divide(periodsPerYear, outputScale, roundingMode)

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/LatestPeriodType.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/LatestPeriodType.kt
@@ -1,0 +1,19 @@
+package com.superwall.sdk.store.abstractions.product.receipt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class LatestPeriodType {
+    @SerialName("TRIAL")
+    TRIAL,
+
+    @SerialName("SUBSCRIPTION")
+    SUBSCRIPTION,
+
+    @SerialName("PROMOTIONAL")
+    PROMOTIONAL,
+
+    @SerialName("REVOKED")
+    REVOKED,
+}

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/LatestSubscriptionState.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/LatestSubscriptionState.kt
@@ -1,0 +1,19 @@
+package com.superwall.sdk.store.abstractions.product.receipt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class LatestSubscriptionState {
+    @SerialName("GRACE_PERIOD")
+    GRACE_PERIOD,
+
+    @SerialName("EXPIRED")
+    EXPIRED,
+
+    @SerialName("SUBSCRIBED")
+    SUBSCRIBED,
+
+    @SerialName("UNKNOWN")
+    UNKNOWN,
+}

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
@@ -1,13 +1,18 @@
 package com.superwall.sdk.store.abstractions.product.receipt
 
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
 import com.superwall.sdk.billing.Billing
+import com.superwall.sdk.dependencies.ExperimentalPropertiesFactory
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
+import com.superwall.sdk.misc.IOScope
+import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.coordinator.ProductsFetcher
 import kotlinx.coroutines.*
-import java.util.*
+import kotlinx.coroutines.flow.MutableStateFlow
 
 data class InAppPurchase(
     var productIdentifier: String,
@@ -16,11 +21,14 @@ data class InAppPurchase(
 class ReceiptManager(
     private var delegate: ProductsFetcher?,
     private val billing: Billing,
+    private val ioScope: IOScope = IOScope(),
 //    private val receiptData: () -> ByteArray? = ReceiptLogic::getReceiptData
-) {
+) : ExperimentalPropertiesFactory {
     var purchasedSubscriptionGroupIds: Set<String>? = null
     private var _purchases: MutableSet<InAppPurchase> = mutableSetOf()
     private var receiptRefreshCompletion: ((Boolean) -> Unit)? = null
+    private val latestSubscriptionState: MutableStateFlow<Map<String, Any>> =
+        MutableStateFlow(emptyMap())
 
     val purchases: Set<String>
         get() = _purchases.map { it.productIdentifier }.toSet()
@@ -35,18 +43,85 @@ class ReceiptManager(
                 delegate?.products(products.toSet())
             }?.toSet()
 
-    suspend fun refreshReceipt() {
+    fun refreshReceipt() {
         Logger.debug(
             logLevel = LogLevel.debug,
             scope = LogScope.receipts,
             message = "Refreshing receipts",
         )
+        ioScope.launch {
+            latestSubscriptionState.value = lastSubscriptionProperties()
+        }
+    }
 
-        // Code to refresh the receipt goes here
+    init {
+        refreshReceipt()
+    }
 
-        // SW-2218
-        // https://linear.app/superwall/issue/SW-2218/%5Bandroid%5D-%5Bv0%5D-replace-receipt-validation-with-google-play-billing
+    suspend fun lastSubscriptionProperties(): Map<String, Any> =
+        billing
+            .queryAllPurchases()
+            .maxBy {
+                it.purchaseTime
+            }.let {
+                val purchase = it
+                val timeSincePurchase = System.currentTimeMillis() - purchase.purchaseTime
+                val latestSubscriptionWillAutoRenew = it.isAutoRenewing
+                val productIds = purchase.products
+                val product =
+                    billing
+                        .awaitGetProducts(productIds.toSet())
+                        .first()
+                val duration = product.rawStoreProduct.subscriptionPeriod?.toMillis ?: 0
+                val state =
+                    when {
+                        purchase.purchaseState == PurchaseState.PENDING &&
+                            purchase.isAutoRenewing -> LatestSubscriptionState.GRACE_PERIOD
+                        purchase.purchaseState == PurchaseState.PURCHASED &&
+                            timeSincePurchase > duration -> LatestSubscriptionState.EXPIRED
+                        purchase.purchaseState == PurchaseState.PURCHASED &&
+                            purchase.isAutoRenewing &&
+                            timeSincePurchase < duration -> LatestSubscriptionState.SUBSCRIBED
+                        else -> {
+                            SubscriptionStatus.Unknown
+                        }
+                    }
+                mapOf(
+                    "latestSubscriptionPeriodType" to determineLatestPeriodType(purchase, product),
+                    "latestSubscriptionWillAutoRenew" to latestSubscriptionWillAutoRenew,
+                    "latestSubscriptionState" to state,
+                )
+            }
+
+    fun determineLatestPeriodType(
+        purchase: Purchase,
+        productDetails: StoreProduct,
+    ): LatestPeriodType {
+        val phasesWithoutTrial =
+            productDetails.rawStoreProduct.selectedOffer
+                ?.pricingPhases
+                ?.pricingPhaseList
+                ?.dropWhile { it.priceAmountMicros == 0L } ?: emptyList()
+        // Heuristics
+        return when {
+            // If we are in a trial period, it is a trial
+            productDetails.trialPeriodEndDate?.time ?: 0 > System.currentTimeMillis() -> LatestPeriodType.TRIAL
+
+            // Promo period with discounted price - without trial, is there more than one phase where
+            // the price is cheaper?
+            phasesWithoutTrial.size > 1 &&
+                phasesWithoutTrial.first().priceAmountMicros <
+                phasesWithoutTrial.last().priceAmountMicros -> LatestPeriodType.PROMOTIONAL
+
+            // Unknown state - we assume it is revoked
+            purchase.purchaseState == Purchase.PurchaseState.UNSPECIFIED_STATE -> LatestPeriodType.REVOKED
+
+            // If all else doesnt match, then the user is in a subscription
+            else -> LatestPeriodType.SUBSCRIPTION
+        }
     }
 
     fun hasPurchasedProduct(productId: String): Boolean = _purchases.firstOrNull { it.productIdentifier == productId } != null
+
+    override fun experimentalProperties(): Map<String, Any> = experimentalProperties()
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -70,6 +70,7 @@ class TransactionManager(
     },
     private val entitlementsById: (String) -> Set<Entitlement>,
     private val showRestoreDialogForWeb: suspend () -> Unit,
+    private val refreshReceipt: () -> Unit,
 ) {
     sealed class PurchaseSource {
         data class Internal(
@@ -176,6 +177,7 @@ class TransactionManager(
         val lastProduct = transactionsInProgress.entries.last()
         when (result) {
             is InternalPurchaseResult.Purchased -> {
+                refreshReceipt()
                 transactionsInProgress.remove(lastProduct.key)
                 val state = state as PurchasingObserverState.PurchaseResult
                 state.purchases?.forEach { purchase ->


### PR DESCRIPTION
## Changes in this pull request

-  Adds a `SuperwallOption` named `enableExperimentalDeviceVariables`. When set to true, this enables additional device-level variables: `latestSubscriptionPeriodType`, `latestSubscriptionState`, and `latestSubscriptionWillAutoRenew`. These properties provide information about the most recent Google Play subscription on the device and can be used in audience filters. Note that due to their experimental nature, they are subject to change in future updates.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)