### PR TITLE
Ir/fix/entitlement reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 2.3.1
+
+## Fixes
+- Fixes an issue where entitlements would not be reset on time
+- Ensures `redeem` is only done on initial config not on config refresh
+
 ## 2.3.0
 
 ## Enhancements

--- a/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
@@ -8,6 +8,7 @@ import androidx.core.net.toUri
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.superwall.SuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEvent.DeepLink
+import com.superwall.sdk.config.models.ConfigurationStatus
 import com.superwall.sdk.identity.identify
 import com.superwall.sdk.identity.setUserAttributes
 import com.superwall.sdk.misc.AlertControllerFactory
@@ -1016,6 +1017,8 @@ object UITestHandler {
             "Fetched config, subscribed, and not gated. The paywall should NOT show. You " +
                 "should NOT see !!! ERROR HANDLER !!! in the console and the alert SHOULD show.",
             test = { scope, events, message ->
+                Superwall.instance.configurationStateListener.first { it is ConfigurationStatus.Configured }
+                delay(1000)
                 executeRegisterFeatureClosureTest(
                     subscribed = true,
                     gated = false,
@@ -1029,6 +1032,8 @@ object UITestHandler {
             "Fetched config, subscribed, and gated. The paywall should NOT show. You should" +
                 " NOT see !!! ERROR HANDLER !!! in the console and the alert SHOULD show.",
             test = { scope, events, message ->
+                Superwall.instance.configurationStateListener.first { it is ConfigurationStatus.Configured }
+                delay(1000)
                 executeRegisterFeatureClosureTest(
                     subscribed = true,
                     gated = true,

--- a/superwall-compose/build.gradle.kts
+++ b/superwall-compose/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
-version = "2.3.0"
+version = "2.3.1"
 
 android {
     namespace = "com.superwall.sdk.composable"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("signing")
 }
 
-version = "2.3.0"
+version = "2.3.1"
 
 android {
     compileSdk = 35

--- a/superwall/src/androidTest/java/com/superwall/sdk/config/AssignmentsTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/config/AssignmentsTest.kt
@@ -15,6 +15,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -103,7 +104,7 @@ class AssignmentsTest {
 
                 When("We confirm the assignment") {
                     assignments.confirmAssignment(assignment)
-
+                    advanceUntilIdle()
                     Then("The assignment should be confirmed and saved") {
                         verify { storage.getConfirmedAssignments() }
                         verify { storage.saveConfirmedAssignments(any()) }

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -231,6 +231,10 @@ open class ConfigManager(
                 }
             }.then(::processConfig)
             .then {
+                ioScope.launch {
+                    checkForWebEntitlements()
+                }
+            }.then {
                 if (options.paywalls.shouldPreload) {
                     val productIds = it.paywalls.flatMap { it.productIds }.toSet()
                     try {
@@ -325,7 +329,6 @@ open class ConfigManager(
         }
         ioScope.launch {
             storeManager.loadPurchasedProducts()
-            checkForWebEntitlements()
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
@@ -47,12 +47,11 @@ class Entitlements(
     /**
      * Internal backing variable that is set only via setSubscriptionStatus
      */
-    private var backingActive: Set<Entitlement> = emptySet()
+    private var backingActive: MutableSet<Entitlement> = mutableSetOf()
 
     private val _all = mutableSetOf<Entitlement>()
     private val _activeDeviceEntitlements = mutableSetOf<Entitlement>()
     private val _inactive = _all.subtract(backingActive).toMutableSet()
-
     // MARK: - Public Properties
 
     internal var activeDeviceEntitlements: Set<Entitlement>
@@ -72,7 +71,7 @@ class Entitlements(
      * The active entitlements.
      */
     val active: Set<Entitlement>
-        get() = backingActive
+        get() = backingActive + _activeDeviceEntitlements + web
 
     /**
      * The inactive entitlements.
@@ -104,7 +103,7 @@ class Entitlements(
                 if (value.entitlements.isEmpty()) {
                     setSubscriptionStatus(SubscriptionStatus.Inactive)
                 } else {
-                    backingActive = value.entitlements
+                    backingActive.addAll(value.entitlements)
                     _all.addAll(value.entitlements)
                     _inactive.removeAll(value.entitlements)
                     _status.value = value
@@ -113,11 +112,13 @@ class Entitlements(
 
             is SubscriptionStatus.Inactive -> {
                 _activeDeviceEntitlements.clear()
+                backingActive.clear()
                 _inactive.clear()
                 _status.value = value
             }
 
             is SubscriptionStatus.Unknown -> {
+                backingActive.clear()
                 _activeDeviceEntitlements.clear()
                 _inactive.clear()
                 _status.value = value


### PR DESCRIPTION
## Changes in this pull request

## Fixes
- Fixes an issue where entitlements would not be reset on time
- Ensures `redeem` is only done on initial config not on config refresh
### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)