### PR TITLE
Fix redemption issue when deserializing response in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ private_key.pepk
 upload-keystore.jks
 .env
 **/google-services.json
-.claude/
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 2.4.0
+
+## Fixes
+- Fixes an issue where a redemption could succeed but throw an error
+
 ## 2.3.1
 
 ## Fixes

--- a/superwall/src/main/java/com/superwall/sdk/models/internal/WebRedemption.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/internal/WebRedemption.kt
@@ -112,13 +112,14 @@ sealed class RedemptionResult {
         val identifier: PaywallIdentifier,
         @SerialName("placementName")
         val placementName: String,
-        // For “placementParams”, we treat TS’s “Record<string, any>” as a Map<String, JsonElement>.
         @SerialName("placementParams")
         val placementParams: Map<String, JsonElement>,
         @SerialName("variantId")
         val variantId: VariantId,
         @SerialName("experimentId")
         val experimentId: ExperimentId,
+        @SerialName("productIdentifier")
+        val productIdentifier: String? = null,
     )
 }
 

--- a/superwall/src/main/java/com/superwall/sdk/network/SubscriptionService.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/SubscriptionService.kt
@@ -28,6 +28,7 @@ class SubscriptionService(
         Json(json) {
             namingStrategy = null
             explicitNulls = false
+            ignoreUnknownKeys = true
         }
 
     suspend fun redeemToken(


### PR DESCRIPTION
## Changes in this pull request

## Fixes
- Fixes an issue where a redemption could succeed but throw an error

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)