### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/superwall-compose/build.gradle.kts
+++ b/superwall-compose/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     alias(libs.plugins.publisher)
 }
 
-version = "2.3.3"
+version = "2.4.0"
 
 android {
     namespace = "com.superwall.sdk.composable"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     alias(libs.plugins.publisher)
 }
 
-version = "2.3.3"
+version = "2.4.0"
 
 android {
     compileSdk = 35


### PR DESCRIPTION
## Changes in this pull request

## 2.4.0

## Enhancements
- Increases superscript version to 1.0.2 with improved type and null safety during evaluation.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)