### PR TITLE
Reduce noisy logging, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 2.4.1
+
+## Fixes
+- Reduces noisy logging when product is missing an offer
+- Ensures that getting experimental properties works for consumable products
+
 ## 2.4.0
 
 ## Enhancements

--- a/superwall-compose/build.gradle.kts
+++ b/superwall-compose/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     alias(libs.plugins.publisher)
 }
 
-version = "2.4.0"
+version = "2.4.1"
 
 android {
     namespace = "com.superwall.sdk.composable"

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     alias(libs.plugins.publisher)
 }
 
-version = "2.4.0"
+version = "2.4.1"
 
 android {
     compileSdk = 35

--- a/superwall/src/main/java/com/superwall/sdk/models/product/ProductItem.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/product/ProductItem.kt
@@ -147,7 +147,7 @@ object PlayStoreProductSerializer : KSerializer<PlayStoreProduct> {
 
                 else -> {
                     Logger.debug(
-                        LogLevel.error,
+                        LogLevel.debug,
                         LogScope.configManager,
                         "Unknown offer type for $productIdentifier, fallback to none",
                     )

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
@@ -113,8 +113,8 @@ class ReceiptManager(
             // Promo period with discounted price - without trial, is there more than one phase where
             // the price is cheaper?
             phasesWithoutTrial.size > 1 &&
-                phasesWithoutTrial.first().priceAmountMicros <
-                phasesWithoutTrial.last().priceAmountMicros -> LatestPeriodType.PROMOTIONAL
+                (phasesWithoutTrial.firstOrNull()?.priceAmountMicros ?: 0) <
+                (phasesWithoutTrial.lastOrNull()?.priceAmountMicros ?: 0) -> LatestPeriodType.PROMOTIONAL
 
             // Unknown state - we assume it is revoked
             purchase.purchaseState == Purchase.PurchaseState.UNSPECIFIED_STATE -> LatestPeriodType.REVOKED

--- a/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/ErrorTracking.kt
@@ -136,6 +136,7 @@ internal inline fun <T> withErrorTracking(block: () -> T): Either<T, Throwable> 
     try {
         Either.Success(block())
     } catch (e: Throwable) {
+        e.printStackTrace()
         if (e.shouldLog()) {
             if (Superwall.initialized) {
                 Superwall.instance.trackError(e)


### PR DESCRIPTION
## Changes in this pull request

## 2.4.1

## Fixes
- Reduces noisy logging when product is missing an offer
- Ensures that getting experimental properties works for consumable products

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)