### PR TITLE
Expose alert showing, timeout setting, add attributes to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## Enhancements
 - Adds `Superwall.instance.setIntegrationAttributes` method enabling you to set integration identifiers for the users from different platforms (Adjust, Mixpanel, Meta, etc.)
+- Adds `Superwall.instance.showAlert` method enabling you to easily show an alert over the current paywall
+- Adds `PaywallOptions.timeoutAfter` to easily control timeout of paywalls when not using fallback loading
+- Adds user attributes to `TransactionComplete` and `PaywallOpen` events
+- Adds device ID to device attributes
+
+## 
+
 
 ## 2.5.1
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -342,7 +342,10 @@ class Superwall(
         withErrorTracking {
             _integrationAttributes = attributes
 
-            dependencyContainer.storage.write(com.superwall.sdk.storage.IntegrationAttributes, attributes)
+            dependencyContainer.storage.write(
+                com.superwall.sdk.storage.IntegrationAttributes,
+                attributes,
+            )
             ioScope.launch {
                 track(IntegrationAttributes(attributes.mapKeys { it.key.rawName }))
                 dependencyContainer.reedemer.redeem(WebPaywallRedeemer.RedeemType.Existing)
@@ -570,7 +573,9 @@ class Superwall(
                 setSubscriptionStatus(cachedSubscriptionStatus)
 
                 // Load stored integration identifiers
-                _integrationAttributes = dependencyContainer.storage.read(com.superwall.sdk.storage.IntegrationAttributes) ?: emptyMap()
+                _integrationAttributes =
+                    dependencyContainer.storage.read(com.superwall.sdk.storage.IntegrationAttributes)
+                        ?: emptyMap()
 
                 addListeners()
 
@@ -679,6 +684,27 @@ class Superwall(
         }
     }
 
+    /**
+     * Shows an alert with provided properties over the paywall UI.
+     * Will only show if the current paywall exists/is presented.
+     * */
+    fun showAlert(
+        title: String? = null,
+        message: String? = null,
+        actionTitle: String? = null,
+        closeActionTitle: String = "Done",
+        action: (() -> Unit)? = null,
+        onClose: (() -> Unit)? = null,
+    ) {
+        paywallView?.showAlert(
+            title,
+            message,
+            actionTitle,
+            closeActionTitle,
+            action,
+            onClose,
+        )
+    }
     // MARK: - Reset
 
     /**
@@ -1209,10 +1235,15 @@ class Superwall(
                                         )
                                     }
                                 }
+
                                 else -> {
                                     val packageName = dependencyContainer.deviceHelper.urlScheme
-                                    val url = "https://play.google.com/store/apps/details?id=$packageName"
-                                    (activityProvider?.getCurrentActivity() ?: paywallView.encapsulatingActivity?.get())?.startActivity(
+                                    val url =
+                                        "https://play.google.com/store/apps/details?id=$packageName"
+                                    (
+                                        activityProvider?.getCurrentActivity()
+                                            ?: paywallView.encapsulatingActivity?.get()
+                                    )?.startActivity(
                                         Intent(Intent.ACTION_VIEW, Uri.parse(url)),
                                     )
                                 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/TrackingLogic.kt
@@ -9,12 +9,14 @@ import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.paywall.PaywallURL
 import com.superwall.sdk.paywall.view.PaywallView
+import com.superwall.sdk.storage.core_data.convertFromJsonElement
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneOffset
 import java.net.URI
@@ -143,6 +145,7 @@ sealed class TrackingLogic {
                     is Map<*, *> -> value.mapValues { clean(it.value) }.filterValues { it != null }.toMap()
                     is String -> value
                     is Int, is Float, is Double, is Long, is Boolean -> value
+                    is JsonElement -> value.convertFromJsonElement()
                     else -> {
                         try {
                             Json.encodeToString(value)
@@ -157,7 +160,7 @@ sealed class TrackingLogic {
                         }
                     }
                 }
-            } ?: null
+            }
 
         @Throws(Exception::class)
         fun checkNotSuperwallEvent(event: String) {

--- a/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.config.options
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
 // Options for configuring the appearance and behavior of paywalls.
 class PaywallOptions {
     // Determines whether the paywall should use haptic feedback. Defaults to true.
@@ -86,6 +89,10 @@ class PaywallOptions {
 
     // Hide shimmer optimistically
     var optimisticLoading: Boolean = false
+
+    // How long until a paywall timeout is invoked.
+    // If not using fallback loading, settings this will trigger a paywall timeout instead of retrying.
+    var timeoutAfter: Duration = 0.milliseconds
 }
 
 internal fun PaywallOptions.toMap() =

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -874,4 +874,6 @@ class DependencyContainer(
     override fun context(): Context = context
 
     override fun experimentalProperties(): Map<String, Any> = storeManager.receiptManager.experimentalProperties()
+
+    override fun getCurrentUserAttributes(): Map<String, Any> = identityManager.userAttributes
 }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -196,6 +196,10 @@ interface OptionsFactory {
     fun makeSuperwallOptions(): SuperwallOptions
 }
 
+interface AttributesFactory {
+    fun getCurrentUserAttributes(): Map<String, Any>
+}
+
 interface TriggerFactory {
     suspend fun makeTriggers(): Set<String>
 }

--- a/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/device/DeviceHelper.kt
@@ -33,6 +33,8 @@ import com.superwall.sdk.models.enrichment.Enrichment
 import com.superwall.sdk.models.enrichment.EnrichmentRequest
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.models.events.EventData
+import com.superwall.sdk.models.internal.DeviceVendorId
+import com.superwall.sdk.models.internal.VendorId
 import com.superwall.sdk.network.JsonFactory
 import com.superwall.sdk.network.NetworkError
 import com.superwall.sdk.network.SuperwallAPI
@@ -304,6 +306,9 @@ class DeviceHelper(
     val vendorId: String
         get() = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
+    val deviceId: String
+        get() = DeviceVendorId(VendorId(vendorId)).value
+
     var platformWrapper: String = ""
     var platformWrapperVersion: String = ""
 
@@ -557,6 +562,7 @@ class DeviceHelper(
                 appUserId = identityInfo.appUserId ?: "",
                 aliases = aliases,
                 vendorId = vendorId,
+                deviceId = deviceId,
                 appVersion = appVersion,
                 osVersion = osVersion,
                 deviceModel = model,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
@@ -19,6 +19,7 @@ import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEvents
 import com.superwall.sdk.config.models.OnDeviceCaching
 import com.superwall.sdk.config.options.PaywallOptions
+import com.superwall.sdk.dependencies.AttributesFactory
 import com.superwall.sdk.dependencies.OptionsFactory
 import com.superwall.sdk.dependencies.TriggerFactory
 import com.superwall.sdk.game.GameControllerDelegate
@@ -99,7 +100,8 @@ class PaywallView(
 
     interface Factory :
         TriggerFactory,
-        OptionsFactory
+        OptionsFactory,
+        AttributesFactory
     //region Public properties
 
     // MUST be set prior to presentation
@@ -508,7 +510,11 @@ class PaywallView(
     private suspend fun trackOpen() {
         storage.trackPaywallOpen()
         webView.messageHandler.handle(PaywallMessage.PaywallOpen)
-        val trackedEvent = InternalSuperwallEvent.PaywallOpen(info)
+        val trackedEvent =
+            InternalSuperwallEvent.PaywallOpen(
+                info,
+                factory.getCurrentUserAttributes(),
+            )
         Superwall.instance.track(trackedEvent)
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/templating/models/DeviceTemplate.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/templating/models/DeviceTemplate.kt
@@ -13,6 +13,7 @@ data class DeviceTemplate(
     val appUserId: String,
     val aliases: List<String>,
     val vendorId: String,
+    val deviceId: String,
     val appVersion: String,
     val appVersionPadded: String,
     val osVersion: String,

--- a/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/templating/models/DeviceTemplateTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/templating/models/DeviceTemplateTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.util.UUID
 
 class DeviceTemplateTest {
     val json =
@@ -21,6 +22,7 @@ class DeviceTemplateTest {
             appUserId = "user123",
             aliases = listOf("alias1", "alias2"),
             vendorId = "vendor123",
+            deviceId = "\$SuperwallDevice:${UUID.fromString("vendor123")}",
             appVersion = "1.0.0",
             osVersion = "13",
             deviceModel = "Pixel 6",
@@ -98,6 +100,7 @@ class DeviceTemplateTest {
                 appUserId = "user123",
                 aliases = listOf(),
                 vendorId = "vendor123",
+                deviceId = "\$SuperwallDevice:${UUID.fromString("vendor123")}",
                 appVersion = "1.0.0",
                 osVersion = "13",
                 deviceModel = "Pixel 6",


### PR DESCRIPTION

## Changes in this pull request

- Adds `Superwall.instance.showAlert` method enabling you to easily show an alert over the current paywall
- Adds `PaywallOptions.timeoutAfter` to easily control timeout of paywalls when not using fallback loading
- Adds user attributes to `TransactionComplete` and `PaywallOpen` events
- Adds Device ID to device attributes
 
### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)