### PR TITLE
Separate webview and paywall states into immutable classes

### DIFF
--- a/app/src/androidTest/java/com/example/superapp/test/FlowScreenshotTestExecutor.kt
+++ b/app/src/androidTest/java/com/example/superapp/test/FlowScreenshotTestExecutor.kt
@@ -102,8 +102,7 @@ class FlowScreenshotTestExecutor {
                     mainScope
                         .async {
                             Superwall.instance.paywallView
-                                ?.webView
-                                ?.scrollBy(0, 300) ?: kotlin.run {
+                                ?.scrollBy(300) ?: kotlin.run {
                                 throw IllegalStateException("No view found")
                             }
                         }.await()
@@ -113,8 +112,7 @@ class FlowScreenshotTestExecutor {
                     mainScope
                         .async {
                             Superwall.instance.paywallView
-                                ?.webView
-                                ?.scrollTo(0, 0) ?: kotlin.run {
+                                ?.scrollTo(0) ?: kotlin.run {
                                 throw IllegalStateException("No view found")
                             }
                         }.await()

--- a/app/src/androidTest/java/com/example/superapp/test/SimpleScreenshotTestExecutor.kt
+++ b/app/src/androidTest/java/com/example/superapp/test/SimpleScreenshotTestExecutor.kt
@@ -125,12 +125,11 @@ class SimpleScreenshotTestExecutor {
                         .async {
                             // We scroll a bit to display the button
                             Superwall.instance.paywallView
-                                ?.webView
                                 ?.apply {
                                     // Disable the scrollbar for the test
                                     // so its not visible in screenshots
                                     isVerticalScrollBarEnabled = false
-                                    scrollTo(0, 300)
+                                    scrollTo(300)
                                 }
                         }.await()
                     // We delay a bit to ensure the button is visible
@@ -139,9 +138,8 @@ class SimpleScreenshotTestExecutor {
                     mainScope
                         .async {
                             Superwall.instance.paywallView
-                                ?.webView
                                 ?.apply {
-                                    scrollTo(0, 0)
+                                    scrollTo(0)
                                 }
                         }.await()
                     // We delay a bit to ensure scroll has finished

--- a/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/messaging/TestPaywallMessageHandlerDelegate.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/paywall/presentation/rule_logic/vc/webview/messaging/TestPaywallMessageHandlerDelegate.kt
@@ -1,23 +1,17 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.vc.webview.messaging
 
-import android.webkit.WebView
-import com.superwall.sdk.models.events.EventData
-import com.superwall.sdk.models.paywall.Paywall
-import com.superwall.sdk.paywall.presentation.PaywallInfo
-import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
-import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandlerDelegate
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallWebEvent
 
 class TestPaywallMessageHandlerDelegate(
-    override val request: PresentationRequest? = null,
-    override var paywall: Paywall = Paywall.stub(),
-    override val info: PaywallInfo = Paywall.stub().getInfo(EventData.stub()),
-    override val webView: WebView,
-    override var loadingState: PaywallLoadingState = PaywallLoadingState.Unknown(),
-    override val isActive: Boolean = true,
+    override val state: PaywallViewState,
     val onEvent: (PaywallWebEvent) -> Unit = {},
 ) : PaywallMessageHandlerDelegate {
+    override fun updateState(update: PaywallViewState.Updates) {
+        // No-op for test
+    }
+
     override fun eventDidOccur(paywallWebEvent: PaywallWebEvent) {
         onEvent(paywallWebEvent)
     }
@@ -32,5 +26,12 @@ class TestPaywallMessageHandlerDelegate(
 
     override fun presentBrowserExternal(url: String) {
         TODO("Not yet implemented")
+    }
+
+    override fun evaluate(
+        code: String,
+        resultCallback: ((String?) -> Unit)?,
+    ) {
+        resultCallback?.invoke(null)
     }
 }

--- a/superwall/src/androidTest/java/com/superwall/sdk/store/transactions/TransactionManagerTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/store/transactions/TransactionManagerTest.kt
@@ -19,6 +19,7 @@ import com.superwall.sdk.delegate.InternalPurchaseResult
 import com.superwall.sdk.delegate.PurchaseResult
 import com.superwall.sdk.delegate.RestorationResult
 import com.superwall.sdk.misc.ActivityProvider
+import com.superwall.sdk.misc.AlertControllerFactory.AlertProps
 import com.superwall.sdk.misc.AppLifecycleObserver
 import com.superwall.sdk.misc.IOScope
 import com.superwall.sdk.models.entitlements.Entitlement
@@ -30,7 +31,7 @@ import com.superwall.sdk.models.product.ProductItem
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.view.PaywallView
-import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.storage.EventsQueue
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.InternalPurchaseController
@@ -107,8 +108,11 @@ class TransactionManagerTest {
         }
     private val paywallView =
         mockk<PaywallView>(relaxUnitFun = true) {
-            every { info } returns pwInfo
-            every { paywall } returns mockedPaywall
+            every { state } returns
+                mockk {
+                    every { info } returns pwInfo
+                    every { paywall } returns mockedPaywall
+                }
         }
 
     private var purchaseController = mockk<InternalPurchaseController>()
@@ -155,10 +159,15 @@ class TransactionManagerTest {
     }
     private var showRestoreDialogForWeb = {}
 
+    private var mockShowAlert = mockk<(AlertProps) -> Unit>(relaxed = true)
+    private var mockUpdateState = mockk<(String, PaywallViewState.Updates) -> Unit>(relaxed = true)
+
     fun TestScope.manager(
         trManagerFactory: TransactionManager.Factory = transactionManagerFactory,
         track: (TrackableSuperwallEvent) -> Unit = {},
-        dismiss: (paywallView: PaywallView, result: PaywallResult) -> Unit = { _, _ -> },
+        dismiss: (paywallId: String, result: PaywallResult) -> Unit = { _, _ -> },
+        showAlert: (AlertProps) -> Unit = mockShowAlert,
+        updateState: (cacheKey: String, update: PaywallViewState.Updates) -> Unit = mockUpdateState,
         subscriptionStatus: () -> SubscriptionStatus = {
             SubscriptionStatus.Active(entitlements)
         },
@@ -176,6 +185,8 @@ class TransactionManagerTest {
             subscriptionStatus = subscriptionStatus,
             track = { track(it) },
             dismiss = { i, e -> dismiss(i, e) },
+            showAlert = { showAlert(it) },
+            updateState = { cacheKey, update -> updateState(cacheKey, update) },
             eventsQueue = eventsQueue,
             factory = trManagerFactory,
             ioScope = IOScope(this.coroutineContext),
@@ -196,7 +207,7 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase fails") {
@@ -218,7 +229,7 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase fails") {
@@ -270,7 +281,7 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase is successful") {
@@ -416,8 +427,8 @@ class TransactionManagerTest {
                         options = {
                             paywalls.automaticallyDismiss = true
                         },
-                        dismiss = { view, res ->
-                            assert(view == paywallView)
+                        dismiss = { paywallId, res ->
+                            assert(paywallId == paywallView.state.cacheKey)
                             assert(res is PaywallResult.Restored)
                         },
                     )
@@ -504,19 +515,14 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase fails and an alert is shown") {
                         assert(result is PurchaseResult.Failed)
                         coVerify {
-                            paywallView.showAlert(
+                            mockShowAlert.invoke(
                                 any(),
-                                any(),
-                                any(),
-                                any(),
-                                isNull(),
-                                isNull(),
                             )
                         }
                         advanceUntilIdle()
@@ -562,19 +568,14 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase fails and no alert is shown") {
                         assert(result is PurchaseResult.Failed)
                         coVerify(exactly = 0) {
-                            paywallView.showAlert(
+                            mockShowAlert.invoke(
                                 any(),
-                                any(),
-                                any(),
-                                any(),
-                                isNull(),
-                                isNull(),
                             )
                         }
                         And("Verify failure event") {
@@ -614,12 +615,12 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase is pending") {
                         assert(result is PurchaseResult.Pending)
-                        coVerify { paywallView.showAlert(any(), any()) }
+                        coVerify { mockShowAlert.invoke(any()) }
                         And("Verify pending event") {
                             val pendingEvent =
                                 events.value
@@ -659,16 +660,16 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase is pending") {
                         assert(result is PurchaseResult.Cancelled)
                         verify {
-                            paywallView setProperty "loadingState" value
-                                any(
-                                    PaywallLoadingState.Ready::class,
-                                )
+                            mockUpdateState.invoke(
+                                any(),
+                                any<PaywallViewState.Updates.SetLoadingState>(),
+                            )
                         }
                         And("Verify pending event") {
                             val pendingEvent =
@@ -710,10 +711,10 @@ class TransactionManagerTest {
                     Then("The purchase is cancelled") {
                         assert(result is PurchaseResult.Cancelled)
                         verify(exactly = 0) {
-                            paywallView setProperty "loadingState" value
-                                any(
-                                    PaywallLoadingState.Ready::class,
-                                )
+                            mockUpdateState.invoke(
+                                any(),
+                                any<PaywallViewState.Updates.SetLoadingState>(),
+                            )
                         }
                         And("Verify pending event") {
                             val pendingEvent =
@@ -810,13 +811,8 @@ class TransactionManagerTest {
                     Then("The restoration fails") {
                         assert(result is RestorationResult.Failed)
                         coVerify {
-                            paywallView.showAlert(
+                            mockShowAlert.invoke(
                                 any(),
-                                any(),
-                                any(),
-                                any(),
-                                isNull(),
-                                isNull(),
                             )
                         }
                         And("Verify restoration events") {
@@ -851,13 +847,8 @@ class TransactionManagerTest {
                     Then("The restoration fails because subscription is inactive") {
                         assert(result is RestorationResult.Restored)
                         coVerify {
-                            paywallView.showAlert(
+                            mockShowAlert.invoke(
                                 any(),
-                                any(),
-                                any(),
-                                any(),
-                                isNull(),
-                                isNull(),
                             )
                         }
                         And("Verify restoration events") {
@@ -952,7 +943,7 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase is successful") {
@@ -1045,7 +1036,7 @@ class TransactionManagerTest {
                         transactionManager.purchase(
                             TransactionManager.PurchaseSource.Internal(
                                 "product1",
-                                paywallView,
+                                paywallView.state,
                             ),
                         )
                     Then("The purchase is successful") {

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -52,6 +52,7 @@ import com.superwall.sdk.paywall.presentation.internal.dismiss
 import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult.*
 import com.superwall.sdk.paywall.view.PaywallView
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.SuperwallPaywallActivity
 import com.superwall.sdk.paywall.view.delegate.PaywallViewEventCallback
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallWebEvent
@@ -635,7 +636,7 @@ class Superwall(
         ioScope.launchWithTracking {
             val paywallView =
                 dependencyContainer.paywallManager.currentView ?: return@launchWithTracking
-            paywallView.togglePaywallSpinner(isHidden)
+            paywallView.updateState(PaywallViewState.Updates.ToggleSpinner(isHidden))
         }
     }
 
@@ -1136,7 +1137,7 @@ class Superwall(
                                 dependencyContainer.transactionManager.purchase(
                                     Internal(
                                         paywallEvent.productId,
-                                        paywallView,
+                                        paywallView.controller.state,
                                     ),
                                 )
                             } finally {

--- a/superwall/src/main/java/com/superwall/sdk/analytics/DefaultClassifierDataFactory.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/DefaultClassifierDataFactory.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.util.DisplayMetrics
 import android.view.WindowInsets
 import android.view.WindowManager
+import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getSystemService
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -68,7 +69,7 @@ interface ClassifierDataFactory {
             return windowMetrics.bounds.width()
         } else {
             val displayMetrics = DisplayMetrics()
-            windowManager.defaultDisplay.getMetrics(displayMetrics)
+            ContextCompat.getDisplayOrDefault(context()).getMetrics(displayMetrics)
             return displayMetrics.widthPixels
         }
     }
@@ -82,16 +83,14 @@ interface ClassifierDataFactory {
             return windowMetrics.bounds.height()
         } else {
             val displayMetrics = DisplayMetrics()
-            windowManager.defaultDisplay.getMetrics(displayMetrics)
+            ContextCompat.getDisplayOrDefault(context()).getMetrics(displayMetrics)
             return displayMetrics.heightPixels
         }
     }
 
     fun getScreenSize(): Double {
         val point = Point()
-        windowManager.defaultDisplay.getRealSize(
-            point,
-        )
+        ContextCompat.getDisplayOrDefault(context()).getRealSize(point)
         val displayMetrics: DisplayMetrics = context().resources.displayMetrics
         val width = point.x
         val height = point.y

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -92,11 +92,15 @@ sealed class InternalSuperwallEvent(
         override val audienceFilterParams: Map<String, Any>
             get() {
                 val output = paywallInfo.audienceFilterParams()
-                return output +
-                    mapOf(
-                        "survey_selected_option_title" to selectedOption.title,
-                        "survey_custom_response" to customResponse,
-                    ).filter { (_, value) -> value != null } as MutableMap<String, Any>
+                return (
+                    output +
+                        mapOf(
+                            "survey_selected_option_title" to selectedOption.title,
+                            "survey_custom_response" to customResponse,
+                        ).map { (key, value) -> if (value != null) key to value else null }
+                            .filterNotNull()
+                            .toMap()
+                )
             }
 
         override suspend fun getSuperwallParameters(): Map<String, Any> {
@@ -251,8 +255,7 @@ sealed class InternalSuperwallEvent(
                 is State.Fail -> return params
                 is State.Complete -> return HashMap(
                     state.paywallInfo
-                        .eventParams(otherParams = params)
-                        .filterValues { it != null } as Map<String, Any>,
+                        .eventParams(otherParams = params),
                 )
             }
         }
@@ -914,7 +917,9 @@ sealed class InternalSuperwallEvent(
                 "paywall_id" to paywallId,
                 "preloading_enabled" to preloadingEnabled,
                 "visible_duration" to visibleDuration,
-            ).filter { it.value != null }.toMap() as Map<String, Any>
+            ).map { (key, value) -> if (value != null) key to value else null }
+                .filterNotNull()
+                .toMap()
 
         override val canImplicitlyTriggerPaywall: Boolean = false
     }
@@ -1010,6 +1015,7 @@ sealed class InternalSuperwallEvent(
                             .mapValues { it.value.convertFromJsonElement() },
                         state.enrichment.device.mapValues { it.value.convertFromJsonElement() },
                     )
+
                 State.Fail -> SuperwallEvent.EnrichmentFail
                 State.Start -> SuperwallEvent.EnrichmentStart
             },

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-// TODO: Re-enable those params
 open class ConfigManager(
     private val context: Context,
     private val storeManager: StoreManager,

--- a/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
@@ -142,7 +142,11 @@ class PaywallPreload(
         val oldPaywalls = oldConfig.paywalls
         val newPaywalls = newConfig.paywalls
 
-        val presentedPaywallId = paywallManager.currentView?.paywall?.identifier
+        val presentedPaywallId =
+            paywallManager.currentView
+                ?.state
+                ?.paywall
+                ?.identifier
         val oldPaywallCacheIds: Map<PaywallIdentifier, CacheKey> =
             oldPaywalls
                 .map { it.identifier to it.cacheKey }

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugView.kt
@@ -50,6 +50,7 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import com.superwall.sdk.paywall.request.PaywallRequestManager
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.view.ActivityEncapsulatable
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.store.StoreManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -607,7 +608,7 @@ class DebugView(
                 )
         }
 
-        paywallVc.interceptTouchEvents = true
+        paywallVc.updateState(PaywallViewState.Updates.SetInterceptTouchEvents(true))
 
         val constraints =
             ConstraintSet().apply {

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -71,6 +71,7 @@ import com.superwall.sdk.paywall.request.PaywallRequestManager
 import com.superwall.sdk.paywall.request.PaywallRequestManagerDepFactory
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.view.PaywallView
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.SuperwallStoreOwner
 import com.superwall.sdk.paywall.view.ViewModelFactory
 import com.superwall.sdk.paywall.view.ViewStorageViewModel
@@ -382,6 +383,7 @@ class DependencyContainer(
                 },
                 currentPaywallEntitlements = {
                     Superwall.instance.paywallView
+                        ?.state
                         ?.paywall
                         ?.productIds
                         ?.flatMap {
@@ -455,7 +457,11 @@ class DependencyContainer(
                     Superwall.instance.track(it)
                 },
                 dismiss = { it, et ->
-                    Superwall.instance.dismiss(it, et)
+                    val paywallExists = (makeViewStore().retrieveView(it) as PaywallView?)
+                    if (paywallExists == null) {
+                        return@TransactionManager
+                    }
+                    Superwall.instance.dismiss(paywallExists, et)
                 },
                 ioScope = ioScope(),
                 showRestoreDialogForWeb = {
@@ -466,6 +472,23 @@ class DependencyContainer(
                 },
                 refreshReceipt = {
                     storeManager.refreshReceipt()
+                },
+                showAlert = {
+                    Superwall.instance.paywallView?.showAlert(
+                        it.title,
+                        it.message,
+                        it.actionTitle,
+                        it.closeActionTitle,
+                        it.action,
+                        it.onClose,
+                    )
+                },
+                updateState = { key, state ->
+                    val paywallExists = (makeViewStore().retrieveView(key) as PaywallView?)
+                    if (paywallExists == null) {
+                        return@TransactionManager
+                    }
+                    paywallExists.updateState(state)
                 },
             )
 
@@ -563,13 +586,18 @@ class DependencyContainer(
     ): PaywallView {
         val messageHandler =
             PaywallMessageHandler(
-                sessionEventsManager = sessionEventsManager,
                 factory = this@DependencyContainer,
                 ioScope = ioScope,
                 json = paywallJson,
                 mainScope = mainScope(),
             )
 
+        val state =
+            PaywallViewState(
+                paywall = paywall,
+                deviceHelper = deviceHelper,
+            )
+        val controller = PaywallView.PaywallController(state)
         val paywallView =
             uiScope
                 .async {
@@ -585,7 +613,6 @@ class DependencyContainer(
                     val paywallView =
                         PaywallView(
                             context = context,
-                            paywall = paywall,
                             factory = this@DependencyContainer,
                             cache = cache,
                             callback = delegate,
@@ -596,6 +623,7 @@ class DependencyContainer(
                             useMultipleUrls =
                                 configManager.config?.featureFlags?.enableMultiplePaywallUrls
                                     ?: false,
+                            controller = controller,
                         )
                     webView.delegate = paywallView
                     messageHandler.delegate = paywallView
@@ -623,7 +651,11 @@ class DependencyContainer(
 
     override fun makeCache(): PaywallViewCache = PaywallViewCache(context, makeViewStore(), activityProvider!!, deviceHelper)
 
-    override fun activePaywallId(): String? = paywallManager.currentView?.paywall?.identifier
+    override fun activePaywallId(): String? =
+        paywallManager.currentView
+            ?.state
+            ?.paywall
+            ?.identifier
 
     override fun makeDeviceInfo(): DeviceInfo =
         DeviceInfo(
@@ -839,7 +871,7 @@ class DependencyContainer(
                         paywallInfo = paywallView.info,
                     ),
                 )
-                paywallView.webView.messageHandler.handle(PaywallMessage.Restore)
+                paywallView.handle(PaywallMessage.Restore)
             }
             if (makeSuperwallOptions().paywalls.automaticallyDismiss) {
                 ioScope.launch {
@@ -862,7 +894,7 @@ class DependencyContainer(
             ioScope.launch {
                 Superwall.instance.track(trackedEvent)
             }
-            paywallView.webView.messageHandler.handle(PaywallMessage.RestoreFailed(message))
+            paywallView.handle(PaywallMessage.RestoreFailed(message))
             paywallView.showAlert(
                 title = options.paywalls.restoreFailed.title,
                 message = options.paywalls.restoreFailed.message,

--- a/superwall/src/main/java/com/superwall/sdk/misc/AlertControllerFactory.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/AlertControllerFactory.kt
@@ -4,6 +4,15 @@ import android.app.AlertDialog
 import android.content.Context
 
 object AlertControllerFactory {
+    data class AlertProps(
+        val title: String? = null,
+        val message: String? = null,
+        val actionTitle: String? = null,
+        val closeActionTitle: String = "Done",
+        val action: (() -> Unit)? = null,
+        val onClose: (() -> Unit)? = null,
+    )
+
     fun make(
         context: Context,
         title: String? = null,

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallManager.kt
@@ -50,7 +50,7 @@ class PaywallManager(
     fun resetCache() {
         factory.mainScope().launchWithTracking {
             for (view in cache.getAllPaywallViews()) {
-                view.webView.destroy()
+                view.destroyWebview()
                 val inactivePaywalls =
                     cache.entries
                         .filter {
@@ -59,8 +59,8 @@ class PaywallManager(
                         }.values
                         .map { it as PaywallView }
                 for (paywallView in inactivePaywalls) {
-                    if (paywallView.paywall.identifier != cache.activePaywallVcKey) {
-                        paywallView.webView.destroy()
+                    if (paywallView.state.paywall.identifier != cache.activePaywallVcKey) {
+                        paywallView.destroyWebview()
                     }
                 }
                 cache.removeAll()
@@ -88,7 +88,7 @@ class PaywallManager(
                     cache.getPaywallView(cacheKey)?.let { view ->
                         if (!isPreloading) {
                             view.callback = delegate
-                            view.paywall.update(it)
+                            view.state.paywall.update(it)
                         }
                         return@mapAsync view
                     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
@@ -31,11 +31,9 @@ import com.superwall.sdk.misc.AlertControllerFactory
 import com.superwall.sdk.misc.IOScope
 import com.superwall.sdk.misc.MainScope
 import com.superwall.sdk.misc.toResult
-import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.paywall.PaywallPresentationStyle
 import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
 import com.superwall.sdk.network.device.DeviceHelper
-import com.superwall.sdk.paywall.manager.PaywallCacheLogic
 import com.superwall.sdk.paywall.manager.PaywallViewCache
 import com.superwall.sdk.paywall.presentation.PaywallCloseReason
 import com.superwall.sdk.paywall.presentation.PaywallInfo
@@ -49,16 +47,24 @@ import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
 import com.superwall.sdk.paywall.view.delegate.PaywallViewDelegateAdapter
 import com.superwall.sdk.paywall.view.delegate.PaywallViewEventCallback
 import com.superwall.sdk.paywall.view.survey.SurveyManager
-import com.superwall.sdk.paywall.view.survey.SurveyPresentationResult
 import com.superwall.sdk.paywall.view.webview.PaywallMessage
 import com.superwall.sdk.paywall.view.webview.SWWebView
 import com.superwall.sdk.paywall.view.webview.SWWebViewDelegate
+import com.superwall.sdk.paywall.view.webview.SendPaywallMessages
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandlerDelegate
+import com.superwall.sdk.paywall.view.webview.messaging.PaywallStateDelegate
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallWebEvent
 import com.superwall.sdk.storage.LocalStorage
 import com.superwall.sdk.utilities.withErrorTracking
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -72,7 +78,6 @@ import kotlin.time.DurationUnit
 
 class PaywallView(
     context: Context,
-    override var paywall: Paywall,
     val eventCallback: PaywallViewEventCallback? = null,
     var callback: PaywallViewDelegateAdapter? = null,
     val deviceHelper: DeviceHelper,
@@ -81,11 +86,31 @@ class PaywallView(
     webView: SWWebView,
     private val cache: PaywallViewCache?,
     private val useMultipleUrls: Boolean,
+    val controller: PaywallController,
 ) : FrameLayout(context),
     PaywallMessageHandlerDelegate,
     SWWebViewDelegate,
+    PaywallStateDelegate by controller,
     ActivityEncapsulatable,
-    GameControllerDelegate {
+    GameControllerDelegate,
+    SendPaywallMessages by webView.messageHandler {
+    class PaywallController(
+        initialState: PaywallViewState,
+    ) : PaywallStateDelegate {
+        private var _state = MutableStateFlow(initialState)
+        val currentState = _state.asStateFlow()
+        override val state: PaywallViewState
+            get() = _state.value
+
+        override fun updateState(update: PaywallViewState.Updates) {
+            _state.update { currentState ->
+                // Apply the transform to get new state
+                val newState = update.transform(currentState)
+                newState
+            }
+        }
+    }
+
     private companion object {
         private val mainScope: MainScope = MainScope()
         private val ioScope: IOScope = IOScope()
@@ -102,86 +127,42 @@ class PaywallView(
         OptionsFactory
     //region Public properties
 
-    // MUST be set prior to presentation
-    override var request: PresentationRequest? = null
-
     // We use a local webview so we can handle cases where webview process crashes
-    private var _webView: SWWebView = webView
-    override val webView: SWWebView = _webView
+    internal var webView: SWWebView = webView
+        private set
+
+    fun scrollBy(y: Int) {
+        webView.scrollBy(0, y)
+    }
+
+    fun scrollTo(y: Int) {
+        webView.scrollTo(0, y)
+    }
 
     //endregion
 
     //region Presentation properties
 
-    // / The presentation style for the paywall.
-    private var presentationStyle: PaywallPresentationStyle
-
+    // The full screen activity instance if this view has been presented in one.
+    override var encapsulatingActivity: WeakReference<Activity>? = null
     private var shimmerView: PaywallShimmerView? = null
 
     private var loadingView: PaywallPurchaseLoadingView? = null
 
-    var paywallStatePublisher: MutableSharedFlow<PaywallState>? = null
-
-    // The full screen activity instance if this view has been presented in one.
-    override var encapsulatingActivity: WeakReference<Activity>? = null
-
-    // / Stores the ``PaywallResult`` on dismiss of paywall.
-    private var paywallResult: PaywallResult? = null
-
-    // / Stores the completion block when calling dismiss.
-    private var dismissCompletionBlock: (() -> Unit)? = null
-
-    private var callbackInvoked = false
-
-    private var viewCreatedCompletion: ((Boolean) -> Unit)? = null
-
-    // / Defines when Browser is presenting in app.
-    internal var isBrowserViewPresented = false
-
-    internal var interceptTouchEvents = false
-
-    // / Whether the survey was shown, not shown, or in a holdout. Defaults to not shown.
-    private var surveyPresentationResult: SurveyPresentationResult = SurveyPresentationResult.NOSHOW
-
     //endregion
-
     // region State properties
 
     // / The paywall info
     override val info: PaywallInfo
-        get() = paywall.getInfo(request?.presentationInfo?.eventData)
+        get() = controller.state.info
 
     // / The loading state of the paywall.
-    override var loadingState: PaywallLoadingState = PaywallLoadingState.Unknown()
-        set(value) {
-            val oldValue = field
-            field = value
-            if (value::class != oldValue::class) {
-                loadingStateDidChange(oldValue)
-            }
+    var loadingState: PaywallLoadingState
+        get() = state.loadingState
+        private set(value) {
+            controller.updateState(PaywallViewState.Updates.SetLoadingState(value))
         }
 
-    // / Determines whether the paywall is presented or not.
-    override val isActive: Boolean
-        get() = isPresented
-
-    // / Defines whether the view is being presented or not.
-    private var isPresented = false
-    private var presentationWillPrepare = true
-    private var presentationDidFinishPrepare = false
-
-    //endregion
-
-    //region Private properties not used in initializer
-
-    // / `true` if there's a survey to complete and the paywall is displayed in a modal style.
-    private var didDisableSwipeForSurvey = false
-
-    // / If the user match a rule with an occurrence, this needs to be saved on
-    // / paywall presentation.
-    private var unsavedOccurrence: TriggerRuleOccurrence? = null
-
-    private val cacheKey: String = PaywallCacheLogic.key(paywall.identifier, deviceHelper.locale)
     val backgroundColor: Int
         get() {
 
@@ -193,20 +174,21 @@ class PaywallView(
                 }
             return when (style) {
                 Configuration.UI_MODE_NIGHT_YES ->
-                    paywall.darkBackgroundColor
-                        ?: paywall.backgroundColor
+                    state.paywall.darkBackgroundColor
+                        ?: state.paywall.backgroundColor
 
-                else -> paywall.backgroundColor
+                else -> state.paywall.backgroundColor
             }
         }
     //endregion
 
     //region Initialization
 
+    private var stateListener: Job? = null
+
     init {
         id = View.generateViewId()
         setBackgroundColor(backgroundColor)
-        presentationStyle = paywall.presentation.style
     }
 
     //endregion
@@ -216,9 +198,13 @@ class PaywallView(
         paywallStatePublisher: MutableSharedFlow<PaywallState>,
         unsavedOccurrence: TriggerRuleOccurrence?,
     ) {
-        this.request = request
-        this.paywallStatePublisher = paywallStatePublisher
-        this.unsavedOccurrence = unsavedOccurrence
+        controller.updateState(
+            PaywallViewState.Updates.SetRequest(
+                request,
+                paywallStatePublisher,
+                unsavedOccurrence,
+            ),
+        )
     }
 
     internal fun setupShimmer(shimmerView: PaywallShimmerView) {
@@ -267,37 +253,55 @@ class PaywallView(
             setupShimmer(it)
         }
         set(request, paywallStatePublisher, unsavedOccurrence)
-        if (presentationStyleOverride != null && presentationStyleOverride !is PaywallPresentationStyle.None) {
-            presentationStyle = presentationStyleOverride
-        } else {
-            presentationStyle = paywall.presentation.style
-        }
+        controller.updateState(
+            PaywallViewState.Updates.SetPresentationConfig(
+                presentationStyleOverride,
+                completion,
+            ),
+        )
 
         SuperwallPaywallActivity.startWithView(
             presenter,
             this,
-            cacheKey,
-            presentationStyle,
+            state.cacheKey,
+            state.presentationStyle,
         )
-        viewCreatedCompletion = completion
+        stateListener =
+            ioScope.launch {
+                controller.currentState
+                    .map {
+                        it.loadingState
+                    }.distinctUntilChanged { old, new ->
+                        val same = old::class == new::class
+                        same
+                    }.collectLatest {
+                        loadingStateDidChange()
+                    }
+            }
     }
 
+    override fun updateState(update: PaywallViewState.Updates) {
+        controller.updateState(update)
+    }
+
+    override val state: PaywallViewState
+        get() = controller.state
+
     fun beforeViewCreated() {
-        if (isBrowserViewPresented) {
+        if (state.isBrowserViewPresented) {
             return
         }
         shimmerView?.checkForOrientationChanges()
         presentationWillBegin()
     }
 
-    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean = interceptTouchEvents
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean = state.interceptTouchEvents
 
     private fun presentationWillBegin() {
-        if (!presentationWillPrepare) {
+        if (!state.presentationWillPrepare) {
             return
         }
-        callbackInvoked = false
-        paywall.closeReason = PaywallCloseReason.None
+        controller.updateState(PaywallViewState.Updates.PresentationWillBegin)
 
         Superwall.instance.dependencyContainer.delegateAdapter
             .willPresentPaywall(info)
@@ -317,13 +321,12 @@ class PaywallView(
         if (loadingState is PaywallLoadingState.Ready) {
             webView.messageHandler.handle(PaywallMessage.TemplateParamsAndUserAttributes)
         }
-        paywall.shimmerLoadingInfo.startAt = Date()
+        controller.updateState(PaywallViewState.Updates.ShimmerStarted)
         trackShimmerStart()
-        presentationWillPrepare = false
     }
 
     fun beforeOnDestroy() {
-        if (isBrowserViewPresented) {
+        if (state.isBrowserViewPresented) {
             return
         }
         Superwall.instance.presentationItems.paywallInfo = info
@@ -332,7 +335,7 @@ class PaywallView(
     }
 
     suspend fun destroyed() {
-        if (isBrowserViewPresented) {
+        if (state.isBrowserViewPresented) {
             return
         }
 
@@ -344,17 +347,17 @@ class PaywallView(
         val isShowingSpinner =
             loadingState is PaywallLoadingState.LoadingPurchase || loadingState is PaywallLoadingState.ManualLoading
         if (isShowingSpinner) {
-            this.loadingState = PaywallLoadingState.Ready()
+            controller.updateState(PaywallViewState.Updates.SetLoadingState(PaywallLoadingState.Ready))
         }
 
         Superwall.instance.dependencyContainer.delegateAdapter
             .didDismissPaywall(info)
 
-        val result = paywallResult ?: PaywallResult.Declined()
+        val result = state.paywallResult ?: PaywallResult.Declined()
 
-        paywallStatePublisher?.emit(PaywallState.Dismissed(info, result))
+        state.paywallStatePublisher?.emit(PaywallState.Dismissed(info, result))
 
-        if (!callbackInvoked) {
+        if (!state.callbackInvoked) {
             callback?.onFinished(
                 paywall = this,
                 result = result,
@@ -362,23 +365,19 @@ class PaywallView(
             )
         }
 
-        if (paywall.closeReason.stateShouldComplete) {
-            paywallStatePublisher = null
+        if (state.paywall.closeReason.stateShouldComplete) {
+            controller.updateState(PaywallViewState.Updates.ClearStatePublisher)
         }
 
         GameControllerManager.shared.clearDelegate(this)
         resetPresentationPreparations()
 
-        paywallResult = null
+        controller.updateState(PaywallViewState.Updates.CleanupAfterDestroy)
         cache?.activePaywallVcKey = null
-        isPresented = false
-        dismissCompletionBlock?.invoke()
-        dismissCompletionBlock = null
     }
 
     private fun resetPresentationPreparations() {
-        presentationWillPrepare = true
-        presentationDidFinishPrepare = false
+        controller.updateState(PaywallViewState.Updates.ResetPresentationPreparations)
     }
 
     internal fun dismiss(
@@ -386,11 +385,15 @@ class PaywallView(
         closeReason: PaywallCloseReason,
         completion: (() -> Unit)? = null,
     ) {
-        dismissCompletionBlock = completion
-        paywallResult = result
-        paywall.closeReason = closeReason
+        controller.updateState(
+            PaywallViewState.Updates.InitiateDismiss(
+                result,
+                closeReason,
+                completion,
+            ),
+        )
 
-        val isDeclined = paywallResult is PaywallResult.Declined
+        val isDeclined = state.paywallResult is PaywallResult.Declined
         val isManualClose = closeReason is PaywallCloseReason.ManualClose
 
         suspend fun dismissView() {
@@ -404,7 +407,7 @@ class PaywallView(
                             isImplicit = true,
                         )
                     }.toResult()
-                val paywallPresenterEvent = info.presentedByEventWithName
+                val paywallPresenterEvent = state.info.presentedByEventWithName
                 val presentedByPaywallDecline =
                     paywallPresenterEvent == SuperwallEvents.PaywallDecline.rawName
 
@@ -417,7 +420,7 @@ class PaywallView(
             }
 
             callback?.let {
-                callbackInvoked = true
+                controller.updateState(PaywallViewState.Updates.CallbackInvoked)
                 it.onFinished(
                     paywall = this,
                     result = result,
@@ -436,7 +439,7 @@ class PaywallView(
         }
 
         SurveyManager.presentSurveyIfAvailable(
-            paywall.surveys,
+            state.paywall.surveys,
             paywallResult = result,
             paywallCloseReason = closeReason,
             activity =
@@ -446,12 +449,12 @@ class PaywallView(
                 },
             paywallView = this,
             loadingState = loadingState,
-            isDebuggerLaunched = request?.flags?.isDebuggerLaunched == true,
+            isDebuggerLaunched = state.request?.flags?.isDebuggerLaunched == true,
             paywallInfo = info,
             storage = storage,
             factory = factory,
         ) { res ->
-            this.surveyPresentationResult = res
+            controller.updateState(PaywallViewState.Updates.UpdateSurveyState(res))
             dismiss()
         }
     }
@@ -474,23 +477,23 @@ class PaywallView(
     // Lets the view know that presentation has finished.
     // Only called once per presentation.
     fun onViewCreated() {
-        viewCreatedCompletion?.invoke(true)
-        viewCreatedCompletion = null
+        state.viewCreatedCompletion?.invoke(true)
+        controller.updateState(PaywallViewState.Updates.ClearViewCreatedCompletion)
 
-        if (presentationDidFinishPrepare) {
+        if (state.presentationDidFinishPrepare) {
             return
         }
         ioScope.launch {
-            paywallStatePublisher?.let {
-                Superwall.instance.storePresentationObjects(request, it)
+            state.paywallStatePublisher?.let {
+                Superwall.instance.storePresentationObjects(state.request, it)
             }
         }
-        unsavedOccurrence?.let {
+        state.unsavedOccurrence?.let {
             storage.coreDataManager.save(triggerRuleOccurrence = it)
-            unsavedOccurrence = null
+            controller.updateState(PaywallViewState.Updates.ClearUnsavedOccurrence)
         }
 
-        isPresented = true
+        controller.updateState(PaywallViewState.Updates.SetPresentedAndFinished)
         Superwall.instance.dependencyContainer.delegateAdapter
             .didPresentPaywall(info)
         ioScope.launch {
@@ -500,7 +503,6 @@ class PaywallView(
 
         val currentOrientation = resources.configuration.orientation
         initialOrientation = currentOrientation
-        presentationDidFinishPrepare = true
     }
 
     private var initialOrientation: Int? = null
@@ -516,7 +518,7 @@ class PaywallView(
         val trackedEvent =
             InternalSuperwallEvent.PaywallClose(
                 info,
-                surveyPresentationResult,
+                state.surveyPresentationResult,
             )
         Superwall.instance.track(trackedEvent)
     }
@@ -531,8 +533,6 @@ class PaywallView(
 
     //region Presentation
 
-    // This is basically the same as `dismiss(animated: Bool)`
-    // in the original iOS implementation
     private fun dismiss(presentationIsAnimated: Boolean) {
         // TODO: SW-2162 Implement animation support
         // https://linear.app/superwall/issue/SW-2162/%5Bandroid%5D-%5Bv1%5D-get-animated-presentation-working
@@ -565,10 +565,12 @@ class PaywallView(
         val trackedEvent =
             InternalSuperwallEvent.ShimmerLoad(
                 state = InternalSuperwallEvent.ShimmerLoad.State.Started,
-                paywallId = paywall.identifier,
+                paywallId = state.paywall.identifier,
                 visibleDuration = null,
                 preloadingEnabled = factory.makeSuperwallOptions().paywalls.shouldPreload,
-                delay = paywall.presentation.delay.toDouble(),
+                delay =
+                    state.paywall.presentation.delay
+                        .toDouble(),
             )
         ioScope.launch {
             Superwall.instance.track(trackedEvent)
@@ -589,14 +591,14 @@ class PaywallView(
                 it.hideShimmer()
             }
         }
-        val visible = paywall.shimmerLoadingInfo.startAt
+        val visible = state.paywall.shimmerLoadingInfo.startAt
         val now = Date()
-        paywall.shimmerLoadingInfo.endAt = now
+        controller.updateState(PaywallViewState.Updates.ShimmerEnded)
         ioScope.launch {
             val trackedEvent =
                 InternalSuperwallEvent.ShimmerLoad(
                     state = InternalSuperwallEvent.ShimmerLoad.State.Complete,
-                    paywallId = paywall.identifier,
+                    paywallId = state.paywall.identifier,
                     visibleDuration =
                         if (visible != null) {
                             (now.time - visible.time).milliseconds.toDouble(
@@ -605,7 +607,9 @@ class PaywallView(
                         } else {
                             0.0
                         },
-                    delay = paywall.presentation.delay.toDouble(),
+                    delay =
+                        state.paywall.presentation.delay
+                            .toDouble(),
                     preloadingEnabled = factory.makeSuperwallOptions().paywalls.shouldPreload,
                 )
             Superwall.instance.track(trackedEvent)
@@ -646,7 +650,7 @@ class PaywallView(
                 )
             alertController.show()
 
-            loadingState = PaywallLoadingState.Ready()
+            controller.updateState(PaywallViewState.Updates.SetLoadingState(PaywallLoadingState.Ready))
         }
     }
 
@@ -654,29 +658,8 @@ class PaywallView(
 
     //region State
 
-    /**
-     * Hides or displays the paywall spinner.
-     *
-     * @param isHidden A Boolean indicating whether to show or hide the spinner.
-     */
-    fun togglePaywallSpinner(isHidden: Boolean) {
-        when {
-            isHidden -> {
-                if (loadingState is PaywallLoadingState.ManualLoading || loadingState is PaywallLoadingState.LoadingPurchase) {
-                    loadingState = PaywallLoadingState.Ready()
-                }
-            }
-
-            else -> {
-                if (loadingState is PaywallLoadingState.Ready) {
-                    loadingState = PaywallLoadingState.ManualLoading()
-                }
-            }
-        }
-    }
-
-    internal fun loadingStateDidChange(from: PaywallLoadingState) {
-        if (isActive) {
+    internal fun loadingStateDidChange() {
+        if (state.isActive) {
             mainScope.launch {
                 when (loadingState) {
                     is PaywallLoadingState.Unknown -> {
@@ -694,7 +677,7 @@ class PaywallView(
 
                     is PaywallLoadingState.Ready -> {
                         ioScope.launch {
-                            delay(paywall.presentation.delay)
+                            delay(state.paywall.presentation.delay)
                             mainScope.launch {
                                 showRefreshButtonAfterTimeout(false)
                                 hideLoadingView()
@@ -709,10 +692,8 @@ class PaywallView(
 
     fun loadWebView() {
         ioScope.launch {
-            val url = paywall.url
-            if (paywall.webviewLoadingInfo.startAt == null) {
-                paywall.webviewLoadingInfo.startAt = Date()
-            }
+            val url = state.paywall.url
+            controller.updateState(PaywallViewState.Updates.WebLoadingStarted)
 
             launch {
                 val trackedEvent =
@@ -729,7 +710,7 @@ class PaywallView(
                     logLevel = LogLevel.error,
                     scope = LogScope.paywallView,
                     message =
-                        "Webview Process has crashed for paywall with identifier: ${paywall.identifier}.\n" +
+                        "Webview Process has crashed for paywall with identifier: ${state.paywall.identifier}.\n" +
                             "Crashed by the system: ${
                                 if (isOverO) it.didCrash() else "Unknown"
                             } - priority ${
@@ -739,26 +720,26 @@ class PaywallView(
                 recreateWebview()
             }
 
-            webView.scrollEnabled = paywall.isScrollEnabled ?: true
+            webView.scrollEnabled = state.paywall.isScrollEnabled ?: true
             mainScope.launch {
-                if (paywall.onDeviceCache is OnDeviceCaching.Enabled) {
+                if (state.paywall.onDeviceCache is OnDeviceCaching.Enabled) {
                     webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
                 } else {
                     webView.settings.cacheMode = WebSettings.LOAD_DEFAULT
                 }
                 if (useMultipleUrls) {
-                    webView.loadPaywallWithFallbackUrl(paywall)
+                    webView.loadPaywallWithFallbackUrl(state.paywall)
                 } else {
                     webView.loadUrl(url.value)
                 }
             }
-            loadingState = PaywallLoadingState.LoadingURL()
+            controller.updateState(PaywallViewState.Updates.SetLoadingState(PaywallLoadingState.LoadingURL))
         }
     }
 
     private fun recreateWebview() {
         removeView(webView)
-        _webView =
+        webView =
             SWWebView(context, webView.messageHandler, options = {
                 factory.makeSuperwallOptions().paywalls
             })
@@ -778,7 +759,7 @@ class PaywallView(
             val customTabsIntent = CustomTabsIntent.Builder().build()
             customTabsIntent.intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             customTabsIntent.launchUrl(context, parsedUrl.toString().toUri())
-            isBrowserViewPresented = true
+            controller.updateState(PaywallViewState.Updates.SetBrowserPresented(true))
         } catch (e: MalformedURLException) {
             Logger.debug(
                 logLevel = LogLevel.debug,
@@ -815,6 +796,15 @@ class PaywallView(
         }
     }
 
+    override fun evaluate(
+        code: String,
+        resultCallback: ((String?) -> Unit)?,
+    ) {
+        webView.evaluateJavascript(code) {
+            resultCallback?.invoke(code)
+        }
+    }
+
     override fun openDeepLink(url: String) {
         var uri = url.toUri()
         eventDidOccur(PaywallWebEvent.OpenedDeepLink(uri))
@@ -848,15 +838,20 @@ class PaywallView(
         // Check if the view already has a parent
         val parentViewGroup = this@PaywallView.parent as? ViewGroup
         parentViewGroup?.removeView(this@PaywallView)
-        cache?.activePaywallVcKey = cacheKey
+        cache?.activePaywallVcKey = state.cacheKey
     }
 
     fun cleanup() {
         encapsulatingActivity?.clear()
         callback = null
+        webView.onScrollChangeListener = null
         (parent as? ViewGroup)?.removeAllViews()
         removeAllViews()
         detachAllViewsFromParent()
+    }
+
+    internal fun destroyWebview() {
+        webView.destroy()
     }
 
 //endregion

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallViewState.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallViewState.kt
@@ -1,0 +1,242 @@
+package com.superwall.sdk.paywall.view
+
+import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.models.paywall.PaywallPresentationStyle
+import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
+import com.superwall.sdk.network.device.DeviceHelper
+import com.superwall.sdk.paywall.manager.PaywallCacheLogic
+import com.superwall.sdk.paywall.presentation.PaywallCloseReason
+import com.superwall.sdk.paywall.presentation.PaywallInfo
+import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
+import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
+import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
+import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
+import com.superwall.sdk.paywall.view.survey.SurveyPresentationResult
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.util.Date
+
+data class PaywallViewState(
+    val paywall: Paywall,
+    val deviceHelper: DeviceHelper,
+    val request: PresentationRequest? = null,
+    val presentationStyle: PaywallPresentationStyle = paywall.presentation.style,
+    val paywallStatePublisher: MutableSharedFlow<PaywallState>? = null,
+    val paywallResult: PaywallResult? = null,
+    // / Stores the completion block when calling dismiss.
+    val dismissCompletionBlock: (() -> Unit)? = null,
+    val callbackInvoked: Boolean = false,
+    val viewCreatedCompletion: ((Boolean) -> Unit)? = null,
+    // / Defines when Browser is presenting in app.
+    val isBrowserViewPresented: Boolean = false,
+    val interceptTouchEvents: Boolean = false,
+    // / Whether the survey was shown, not shown, or in a holdout. Defaults to not shown.
+    val surveyPresentationResult: SurveyPresentationResult = SurveyPresentationResult.NOSHOW,
+    val loadingState: PaywallLoadingState = PaywallLoadingState.Unknown,
+    // / Defines whether the view is being presented or not.
+    val isPresented: Boolean = false,
+    val presentationWillPrepare: Boolean = true,
+    val presentationDidFinishPrepare: Boolean = false,
+    // / `true` if there's a survey to complete and the paywall is displayed in a modal style.
+    val didDisableSwipeForSurvey: Boolean = false,
+    // / If the user match a rule with an occurrence, this needs to be saved on paywall presentation.
+    val unsavedOccurrence: TriggerRuleOccurrence? = null,
+) {
+    val info: PaywallInfo
+        get() = paywall.getInfo(request?.presentationInfo?.eventData)
+
+    // / Determines whether the paywall is presented or not.
+    val isActive: Boolean
+        get() = isPresented
+
+    internal val cacheKey: String = PaywallCacheLogic.key(paywall.identifier, deviceHelper.locale)
+
+    override fun toString(): String =
+        """PaywallViewState(
+            |  paywallId: ${paywall.identifier}
+            |  presentationStyle: $presentationStyle
+            |  loadingState: $loadingState
+            |  isPresented: $isPresented
+            |  isActive: $isActive
+            |  presentationWillPrepare: $presentationWillPrepare
+            |  presentationDidFinishPrepare: $presentationDidFinishPrepare
+            |  callbackInvoked: $callbackInvoked
+            |  isBrowserViewPresented: $isBrowserViewPresented
+            |  interceptTouchEvents: $interceptTouchEvents
+            |  surveyPresentationResult: $surveyPresentationResult
+            |  paywallResult: $paywallResult
+            |  hasRequest: ${request != null}
+            |  hasStatePublisher: ${paywallStatePublisher != null}
+            |  hasUnsavedOccurrence: ${unsavedOccurrence != null}
+            |  hasViewCreatedCompletion: ${viewCreatedCompletion != null}
+            |  hasDismissCompletionBlock: ${dismissCompletionBlock != null}
+            |)
+        """.trimMargin()
+
+    sealed class Updates(
+        val transform: (PaywallViewState) -> PaywallViewState,
+    ) {
+        class SetRequest(
+            val req: PresentationRequest,
+            val publisher: MutableSharedFlow<PaywallState>?,
+            val occurrence: TriggerRuleOccurrence?,
+        ) : Updates({ state ->
+                state.copy(
+                    request = req,
+                    paywallStatePublisher = publisher,
+                    unsavedOccurrence = occurrence,
+                )
+            })
+
+        class SetPresentationConfig(
+            val styleOverride: PaywallPresentationStyle?,
+            val completion: ((Boolean) -> Unit)?,
+        ) : Updates({ state ->
+                state.copy(
+                    presentationStyle =
+                        if (styleOverride != null && styleOverride !is PaywallPresentationStyle.None) {
+                            styleOverride
+                        } else {
+                            state.paywall.presentation.style
+                        },
+                    viewCreatedCompletion = completion,
+                )
+            })
+
+        object PresentationWillBegin : Updates({ state ->
+            state.paywall.closeReason = PaywallCloseReason.None
+            state.copy(callbackInvoked = false)
+        })
+
+        object ShimmerStarted : Updates({ state ->
+            state.paywall.shimmerLoadingInfo.startAt = Date()
+            state.copy(presentationWillPrepare = false)
+        })
+
+        object ResetPresentationPreparations : Updates({ state ->
+            state.copy(
+                presentationWillPrepare = true,
+                presentationDidFinishPrepare = false,
+            )
+        })
+
+        class InitiateDismiss(
+            val result: PaywallResult,
+            val closeReason: PaywallCloseReason,
+            val completion: (() -> Unit)?,
+        ) : Updates({ state ->
+                state.paywall.closeReason = closeReason
+                state.copy(
+                    dismissCompletionBlock = completion,
+                    paywallResult = result,
+                )
+            })
+
+        object CallbackInvoked : Updates({ state ->
+            state.copy(callbackInvoked = true)
+        })
+
+        class UpdateSurveyState(
+            val result: SurveyPresentationResult,
+        ) : Updates({ state ->
+                state.copy(surveyPresentationResult = result)
+            })
+
+        object CleanupAfterDestroy : Updates({ state ->
+            state.dismissCompletionBlock?.invoke()
+            state.copy(
+                paywallResult = null,
+                isPresented = false,
+                dismissCompletionBlock = null,
+            )
+        })
+
+        object ClearViewCreatedCompletion : Updates({ state ->
+            state.copy(viewCreatedCompletion = null)
+        })
+
+        object ClearUnsavedOccurrence : Updates({ state ->
+            state.copy(unsavedOccurrence = null)
+        })
+
+        object SetPresentedAndFinished : Updates({ state ->
+            state.copy(
+                isPresented = true,
+                presentationDidFinishPrepare = true,
+            )
+        })
+
+        object ShimmerEnded : Updates({ state ->
+            state.paywall.shimmerLoadingInfo.endAt = Date()
+            state
+        })
+
+        object WebLoadingStarted : Updates({ state ->
+            if (state.paywall.webviewLoadingInfo.startAt == null) {
+                state.paywall.webviewLoadingInfo.startAt = Date()
+            }
+            state
+        })
+
+        object WebLoadingFailed : Updates({ state ->
+            if (state.paywall.webviewLoadingInfo.failAt == null) {
+                state.paywall.webviewLoadingInfo.failAt = Date()
+            }
+            state
+        })
+
+        class SetInterceptTouchEvents(
+            val intercept: Boolean,
+        ) : Updates({ state ->
+                state.copy(interceptTouchEvents = intercept)
+            })
+
+        class SetBrowserPresented(
+            val presented: Boolean,
+        ) : Updates({ state ->
+                state.copy(isBrowserViewPresented = presented)
+            })
+
+        class SetLoadingState(
+            val newState: PaywallLoadingState,
+        ) : Updates({ state ->
+                state.copy(loadingState = newState)
+            })
+
+        object ClearStatePublisher : Updates({
+            it.copy(paywallStatePublisher = null)
+        })
+
+        /**
+         * Hides or displays the paywall spinner.
+         *
+         * @param isHidden A Boolean indicating whether to show or hide the spinner.
+         */
+
+        data class ToggleSpinner(
+            val hidden: Boolean,
+        ) : Updates({ state ->
+                when {
+                    hidden -> {
+                        if (state.loadingState is PaywallLoadingState.ManualLoading ||
+                            state.loadingState is PaywallLoadingState.LoadingPurchase
+                        ) {
+                            state.copy(loadingState = PaywallLoadingState.Ready)
+                        } else {
+                            state
+                        }
+                    }
+
+                    else -> {
+                        if (state.loadingState is PaywallLoadingState.Ready) {
+                            state.copy(
+                                loadingState =
+                                    PaywallLoadingState.ManualLoading,
+                            )
+                        } else {
+                            state
+                        }
+                    }
+                }
+            })
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/SuperwallPaywallActivity.kt
@@ -94,7 +94,8 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                         )
                         putExtra(
                             IS_LIGHT_BACKGROUND_KEY,
-                            view.paywall.backgroundColor.isLightColor(),
+                            view.state.paywall.backgroundColor
+                                .isLightColor(),
                         )
                         flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
                     }
@@ -113,7 +114,7 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             if (children.none { it is LoadingView || it is ShimmerView }) {
                 val loading =
                     (viewStorageViewModel.retrieveView(LoadingView.TAG) as LoadingView)
-                val style = paywall.presentation.style
+                val style = state.paywall.presentation.style
                 val shimmer =
                     if (style is PaywallPresentationStyle.Popup) {
                         ShimmerView(this@prepareViewForDisplay.context).apply {
@@ -325,12 +326,17 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                 // Set the navigation bar color to the paywall background color
                 enableEdgeToEdge(
                     navigationBarStyle =
-                        when (view.paywall.backgroundColor.isDarkColor()) {
-                            true -> SystemBarStyle.dark(view.paywall.backgroundColor)
+                        when (
+                            view.state.paywall.backgroundColor
+                                .isDarkColor()
+                        ) {
+                            true -> SystemBarStyle.dark(view.state.paywall.backgroundColor)
                             else ->
                                 SystemBarStyle.light(
-                                    scrim = view.paywall.backgroundColor,
-                                    darkScrim = view.paywall.backgroundColor.readableOverlayColor(),
+                                    scrim = view.state.paywall.backgroundColor,
+                                    darkScrim =
+                                        view.state.paywall.backgroundColor
+                                            .readableOverlayColor(),
                                 )
                         },
                 )
@@ -355,12 +361,17 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                 }
                 enableEdgeToEdge(
                     navigationBarStyle =
-                        when (view.paywall.backgroundColor.isDarkColor()) {
-                            true -> SystemBarStyle.dark(view.paywall.backgroundColor)
+                        when (
+                            view.state.paywall.backgroundColor
+                                .isDarkColor()
+                        ) {
+                            true -> SystemBarStyle.dark(view.state.paywall.backgroundColor)
                             else ->
                                 SystemBarStyle.light(
-                                    scrim = view.paywall.backgroundColor,
-                                    darkScrim = view.paywall.backgroundColor.readableOverlayColor(),
+                                    scrim = view.state.paywall.backgroundColor,
+                                    darkScrim =
+                                        view.state.paywall.backgroundColor
+                                            .readableOverlayColor(),
                                 )
                         },
                 )
@@ -518,8 +529,8 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         super.onStart()
         val paywallVc = paywallView() ?: return
 
-        if (paywallVc.isBrowserViewPresented) {
-            paywallVc.isBrowserViewPresented = false
+        if (paywallVc.state.isBrowserViewPresented) {
+            paywallVc.updateState(PaywallViewState.Updates.SetBrowserPresented(true))
         }
 
         paywallVc.beforeViewCreated()
@@ -640,7 +651,6 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                 "Error cleaning up PaywallView: $it",
             )
         }
-        paywallView()?.webView?.onScrollChangeListener = null
         paywallView()?.cleanup()
         content?.removeAllViews()
         // Clear reference to activity in the view

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/delegate/PaywallViewCallback.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/delegate/PaywallViewCallback.kt
@@ -20,13 +20,13 @@ fun interface PaywallViewEventCallback {
 }
 
 sealed class PaywallLoadingState {
-    class Unknown : PaywallLoadingState()
+    object Unknown : PaywallLoadingState()
 
-    class LoadingPurchase : PaywallLoadingState()
+    object LoadingPurchase : PaywallLoadingState()
 
-    class LoadingURL : PaywallLoadingState()
+    object LoadingURL : PaywallLoadingState()
 
-    class ManualLoading : PaywallLoadingState()
+    object ManualLoading : PaywallLoadingState()
 
-    class Ready : PaywallLoadingState()
+    object Ready : PaywallLoadingState()
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/SWWebView.kt
@@ -19,6 +19,7 @@ import android.webkit.WebViewClient
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent
 import com.superwall.sdk.config.options.PaywallOptions
 import com.superwall.sdk.game.dispatchKeyEvent
 import com.superwall.sdk.game.dispatchMotionEvent
@@ -29,6 +30,7 @@ import com.superwall.sdk.misc.IOScope
 import com.superwall.sdk.misc.MainScope
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.paywall.presentation.PaywallInfo
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandler
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandlerDelegate
@@ -37,22 +39,26 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
-import java.util.Date
 
 @Suppress("ktlint:standard:class-naming")
-interface _SWWebViewDelegate {
+interface PaywallInfoDelegate {
     val info: PaywallInfo
 }
 
 interface SWWebViewDelegate :
-    _SWWebViewDelegate,
+    PaywallInfoDelegate,
     PaywallMessageHandlerDelegate
+
+interface SendPaywallMessages {
+    fun handle(message: PaywallMessage)
+}
 
 class SWWebView(
     context: Context,
     val messageHandler: PaywallMessageHandler,
     private val onFinishedLoading: ((url: String) -> Unit)? = null,
     private val options: () -> PaywallOptions,
+    private val track: suspend (TrackableSuperwallEvent) -> Unit = { Superwall.instance.track(it) },
 ) : WebView(context) {
     var delegate: SWWebViewDelegate? = null
     private val mainScope = MainScope()
@@ -270,7 +276,11 @@ class SWWebView(
 
                             is WebviewClientEvent.OnPageFinished -> {
                                 if (options().optimisticLoading) {
-                                    delegate?.loadingState = PaywallLoadingState.Ready()
+                                    delegate?.updateState(
+                                        PaywallViewState.Updates.SetLoadingState(
+                                            PaywallLoadingState.Ready,
+                                        ),
+                                    )
                                 }
                                 onFinishedLoading?.invoke(it.url)
                             }
@@ -286,7 +296,7 @@ class SWWebView(
 
     private fun trackLoadFallback() {
         mainScope.launch {
-            delegate?.paywall?.webviewLoadingInfo?.failAt = Date()
+            delegate?.updateState(PaywallViewState.Updates.WebLoadingFailed)
 
             val paywallInfo = delegate?.info ?: return@launch
 
@@ -296,7 +306,7 @@ class SWWebView(
                         InternalSuperwallEvent.PaywallWebviewLoad.State.Fallback,
                     paywallInfo = paywallInfo,
                 )
-            Superwall.instance.track(trackedEvent)
+            track(trackedEvent)
         }
     }
 
@@ -305,7 +315,7 @@ class SWWebView(
         urls: List<String>,
     ) {
         mainScope.launch {
-            delegate?.paywall?.webviewLoadingInfo?.failAt = Date()
+            delegate?.updateState(PaywallViewState.Updates.WebLoadingFailed)
 
             val paywallInfo = delegate?.info ?: return@launch
 
@@ -318,7 +328,7 @@ class SWWebView(
                         ),
                     paywallInfo = paywallInfo,
                 )
-            Superwall.instance.track(trackedEvent)
+            track(trackedEvent)
         }
     }
 
@@ -332,7 +342,7 @@ class SWWebView(
                     url = url,
                     error = error.toString(),
                 )
-            Superwall.instance.track(trackedEvent)
+            track(trackedEvent)
         }
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -27,6 +27,7 @@ import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.ActivityProvider
+import com.superwall.sdk.misc.AlertControllerFactory.AlertProps
 import com.superwall.sdk.misc.IOScope
 import com.superwall.sdk.misc.launchWithTracking
 import com.superwall.sdk.models.entitlements.Entitlement
@@ -35,6 +36,7 @@ import com.superwall.sdk.models.paywall.LocalNotificationType
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.view.PaywallView
+import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.SuperwallPaywallActivity
 import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
 import com.superwall.sdk.storage.EventsQueue
@@ -64,19 +66,24 @@ class TransactionManager(
     private val track: suspend (TrackableSuperwallEvent) -> Unit = {
         Superwall.instance.track(it)
     },
-    private val dismiss: suspend (paywallView: PaywallView, result: PaywallResult) -> Unit,
+    private val dismiss: suspend (paywallId: String, result: PaywallResult) -> Unit,
+    private val showAlert: (AlertProps) -> Unit,
     private val subscriptionStatus: () -> SubscriptionStatus = {
         Superwall.instance.entitlements.status.value
     },
     private val entitlementsById: (String) -> Set<Entitlement>,
     private val showRestoreDialogForWeb: suspend () -> Unit,
     private val refreshReceipt: () -> Unit,
+    private val updateState: (cacheKey: String, update: PaywallViewState.Updates) -> Unit,
 ) {
     sealed class PurchaseSource {
         data class Internal(
             val productId: String,
-            val paywallView: PaywallView,
-        ) : PurchaseSource()
+            val state: PaywallViewState,
+        ) : PurchaseSource() {
+            val paywallInfo: PaywallInfo
+                get() = state.info
+        }
 
         data class ExternalPurchase(
             val product: StoreProduct,
@@ -97,8 +104,6 @@ class TransactionManager(
         HasExternalPurchaseControllerFactory,
         HasInternalPurchaseControllerFactory,
         WebToAppFactory
-
-    private var lastPaywallView: PaywallView? = null
 
     private var transactionsInProgress: ConcurrentHashMap<String, ProductDetails> =
         ConcurrentHashMap()
@@ -317,7 +322,7 @@ class TransactionManager(
                         presentAlert(
                             Error(result.errorMessage),
                             product,
-                            purchaseSource.paywallView,
+                            purchaseSource.state,
                         )
                     }
                 } else {
@@ -327,7 +332,10 @@ class TransactionManager(
                         purchaseSource,
                     )
                     if (purchaseSource is PurchaseSource.Internal) {
-                        purchaseSource.paywallView.togglePaywallSpinner(isHidden = true)
+                        updateState(
+                            purchaseSource.paywallInfo.cacheKey,
+                            PaywallViewState.Updates.ToggleSpinner(hidden = true),
+                        )
                     }
                 }
             }
@@ -366,7 +374,7 @@ class TransactionManager(
         val trackedEvent =
             InternalSuperwallEvent.Transaction(
                 state = InternalSuperwallEvent.Transaction.State.Restore(restoreType),
-                paywallInfo = if (purchaseSource is PurchaseSource.Internal) purchaseSource.paywallView.info else PaywallInfo.empty(),
+                paywallInfo = if (purchaseSource is PurchaseSource.Internal) purchaseSource.paywallInfo else PaywallInfo.empty(),
                 product = product,
                 model = null,
                 isObserved = factory.makeSuperwallOptions().shouldObservePurchases,
@@ -382,7 +390,7 @@ class TransactionManager(
         val superwallOptions = factory.makeSuperwallOptions()
         if (superwallOptions.paywalls.automaticallyDismiss && purchaseSource is PurchaseSource.Internal) {
             dismiss(
-                purchaseSource.paywallView,
+                purchaseSource.paywallInfo.cacheKey,
                 PaywallResult.Restored(),
             )
         }
@@ -401,12 +409,12 @@ class TransactionManager(
                     info =
                         mapOf(
                             "product_id" to product.fullIdentifier,
-                            "paywall_vc" to purchaseSource.paywallView,
+                            "paywall_state" to purchaseSource.state,
                         ),
                 )
 
                 ioScope.launchWithTracking {
-                    val paywallInfo = purchaseSource.paywallView.info
+                    val paywallInfo = purchaseSource.paywallInfo
                     val trackedEvent =
                         InternalSuperwallEvent.Transaction(
                             state =
@@ -473,7 +481,7 @@ class TransactionManager(
                     )
                 }
 
-                val paywallInfo = source.paywallView.info
+                val paywallInfo = source.paywallInfo
                 val trackedEvent =
                     InternalSuperwallEvent.Transaction(
                         InternalSuperwallEvent.Transaction.State.Start(product),
@@ -484,10 +492,6 @@ class TransactionManager(
                         source = TransactionSource.INTERNAL,
                     )
                 track(trackedEvent)
-
-                source.paywallView.loadingState = PaywallLoadingState.LoadingPurchase()
-
-                lastPaywallView = source.paywallView
             }
 
             is PurchaseSource.ExternalPurchase, is PurchaseSource.ObserverMode -> {
@@ -547,7 +551,7 @@ class TransactionManager(
                         info =
                             mapOf(
                                 "product_id" to product.fullIdentifier,
-                                "paywall_vc" to purchaseSource.paywallView,
+                                "paywall_state" to purchaseSource.state,
                             ),
                     )
                 }
@@ -564,7 +568,7 @@ class TransactionManager(
 
                 if (factory.makeSuperwallOptions().paywalls.automaticallyDismiss) {
                     dismiss(
-                        purchaseSource.paywallView,
+                        purchaseSource.paywallInfo.cacheKey,
                         PaywallResult.Purchased(product.fullIdentifier),
                     )
                 }
@@ -613,12 +617,12 @@ class TransactionManager(
                         info =
                             mapOf(
                                 "product_id" to product.fullIdentifier,
-                                "paywall_vc" to purchaseSource.paywallView,
+                                "paywall_state" to purchaseSource.state,
                             ),
                     )
                 }
 
-                val paywallInfo = purchaseSource.paywallView.info
+                val paywallInfo = purchaseSource.paywallInfo
                 val trackedEvent =
                     InternalSuperwallEvent.Transaction(
                         InternalSuperwallEvent.Transaction.State.Abandon(product),
@@ -630,7 +634,12 @@ class TransactionManager(
                     )
                 track(trackedEvent)
 
-                purchaseSource.paywallView.loadingState = PaywallLoadingState.Ready()
+                updateState(
+                    paywallInfo.cacheKey,
+                    PaywallViewState.Updates.SetLoadingState(
+                        PaywallLoadingState.Ready,
+                    ),
+                )
             }
 
             is PurchaseSource.ExternalPurchase, is PurchaseSource.ObserverMode -> {
@@ -664,11 +673,11 @@ class TransactionManager(
                 ioScope.launch {
                     log(
                         message = "Transaction Pending",
-                        info = mapOf("paywall_vc" to purchaseSource.paywallView),
+                        info = mapOf("paywall" to purchaseSource.paywallInfo),
                     )
                 }
 
-                val paywallInfo = purchaseSource.paywallView.info
+                val paywallInfo = purchaseSource.paywallInfo
 
                 val trackedEvent =
                     InternalSuperwallEvent.Transaction(
@@ -681,9 +690,11 @@ class TransactionManager(
                     )
                 track(trackedEvent)
 
-                purchaseSource.paywallView.showAlert(
-                    "Waiting for Approval",
-                    "Thank you! This purchase is pending approval from your parent. Please try again once it is approved.",
+                showAlert(
+                    AlertProps(
+                        "Waiting for Approval",
+                        "Thank you! This purchase is pending approval from your parent. Please try again once it is approved.",
+                    ),
                 )
             }
 
@@ -716,9 +727,8 @@ class TransactionManager(
      */
     suspend fun tryToRestorePurchases(paywallView: PaywallView?): RestorationResult {
         log(message = "Attempting Restore")
-        lastPaywallView = paywallView
         val paywallInfo = paywallView?.info ?: PaywallInfo.empty()
-        paywallView?.loadingState = PaywallLoadingState.LoadingPurchase()
+        paywallView?.updateState(PaywallViewState.Updates.SetLoadingState(PaywallLoadingState.LoadingPurchase))
 
         track(
             InternalSuperwallEvent.Restore(
@@ -737,6 +747,7 @@ class TransactionManager(
         val webToAppEnabled = factory.isWebToAppEnabled()
         val allPaywallEntitlements =
             paywallView
+                ?.state
                 ?.paywall
                 ?.productIds
                 ?.map {
@@ -754,10 +765,14 @@ class TransactionManager(
                     ),
                 )
                 if (paywallView != null) {
-                    didRestore(null, PurchaseSource.Internal("", paywallView))
+                    didRestore(null, PurchaseSource.Internal("", paywallView.state))
                 }
             } else {
-                paywallView?.loadingState = PaywallLoadingState.Ready()
+                paywallView?.updateState(
+                    PaywallViewState.Updates.SetLoadingState(
+                        PaywallLoadingState.Ready,
+                    ),
+                )
                 askToRestoreFromWeb()
             }
         } else {
@@ -811,24 +826,27 @@ class TransactionManager(
         val hasSubsText =
             "Your Play Store subscriptions were restored. Would you like to check for more on the web?"
         val noSubsText = "No Play Store subscription found, would you like to check on the web?"
-        lastPaywallView?.showAlert(
-            title =
-                if (hasEntitlements) "Restore via the web?" else "No Subscription Found",
-            message =
-                if (hasEntitlements) hasSubsText else noSubsText,
-            closeActionTitle =
-                "Close",
-            actionTitle = "Yes",
-            action = {
-                Superwall.instance.openRestoreOnWeb()
-            },
+
+        showAlert(
+            AlertProps(
+                title =
+                    if (hasEntitlements) "Restore via the web?" else "No Subscription Found",
+                message =
+                    if (hasEntitlements) hasSubsText else noSubsText,
+                closeActionTitle =
+                    "Close",
+                actionTitle = "Yes",
+                action = {
+                    Superwall.instance.openRestoreOnWeb()
+                },
+            ),
         )
     }
 
     private suspend fun presentAlert(
         error: Error,
         product: StoreProduct,
-        paywallView: PaywallView,
+        state: PaywallViewState,
     ) {
         ioScope.launch {
             log(
@@ -836,15 +854,17 @@ class TransactionManager(
                 info =
                     mapOf(
                         "product_id" to product.fullIdentifier,
-                        "paywall_vc" to paywallView,
+                        "paywall_state" to state,
                     ),
                 error = error,
             )
         }
 
-        paywallView.showAlert(
-            "An error occurred",
-            error.message ?: "Unknown error",
+        showAlert(
+            AlertProps(
+                "An error occurred",
+                error.message ?: "Unknown error",
+            ),
         )
     }
 
@@ -859,12 +879,11 @@ class TransactionManager(
 
         when (purchaseSource) {
             is PurchaseSource.Internal -> {
-                val paywallView = lastPaywallView ?: return
-
-                val paywallShowingFreeTrial = paywallView.paywall.isFreeTrialAvailable == true
+                val paywallShowingFreeTrial =
+                    purchaseSource.state.paywall.isFreeTrialAvailable
                 val didStartFreeTrial = product.hasFreeTrial && paywallShowingFreeTrial
                 val deviceAttributes = factory.makeSessionDeviceAttributes()
-                val paywallInfo = paywallView.info
+                val paywallInfo = purchaseSource.paywallInfo
 
                 val trackedEvent =
                     InternalSuperwallEvent.Transaction(
@@ -896,7 +915,16 @@ class TransactionManager(
                         val notifications =
                             paywallInfo.localNotifications.filter { it.type == LocalNotificationType.TrialStarted }
                         val paywallActivity =
-                            paywallView.encapsulatingActivity?.get() as? SuperwallPaywallActivity
+                            (
+                                (
+                                    Superwall.instance.paywallView
+                                        ?.encapsulatingActivity
+                                        ?.get()
+                                        ?: Superwall.instance.dependencyContainer
+                                            .activityProvider
+                                            ?.getCurrentActivity()
+                                ) as SuperwallPaywallActivity?
+                            )
                                 ?: return
                         paywallActivity.attemptToScheduleNotifications(
                             notifications = notifications,
@@ -908,8 +936,6 @@ class TransactionManager(
                         track(subscriptionEvent)
                     }
                 }
-
-                lastPaywallView = null
             }
 
             is PurchaseSource.ExternalPurchase, is PurchaseSource.ObserverMode -> {


### PR DESCRIPTION
## Changes in this pull request

- Extracts webview and paywall states into immutable classes with strictly defined updates
- Narrows the scope of some accessors and interfaces
- Implements a controller for simple DI

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)