### PR TITLE
Ensure paywall composable reapplies theme when it changes

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
@@ -582,6 +582,10 @@ class PaywallView(
         }
     }
 
+    fun onThemeChanged() {
+        webView.messageHandler.handle(PaywallMessage.TemplateParamsAndUserAttributes)
+    }
+
     private fun showShimmerView() {
         shimmerView?.let {
             mainScope.launch {


### PR DESCRIPTION
## Changes in this pull request

- Fixes issue with paywall composable not reapplying theme when changed (i.e. Light to Dark)

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)